### PR TITLE
Add per-scene character placement

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -5,6 +5,8 @@ class Character {
     this.state = 'idle';
     this.x = random(100, 700);
     this.y = random(300, 500);
+    // default display scale (35% of original)
+    this.scale = 0.35;
     this.preloadImages();
   }
 
@@ -15,8 +17,8 @@ class Character {
     });
   }
 
-  display() {
-    image(this.images[this.state], this.x, this.y, 100, 100);
+  display(x = this.x, y = this.y, scale = this.scale) {
+    image(this.images[this.state], x, y, 100 * scale, 100 * scale);
   }
 
   setState(newState) {

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -1,4 +1,23 @@
 let scenes = {};
+// Map of characters that appear in each scene with positioning and scale
+let sceneCharacters = {
+  batCave: [
+    {name: 'duck', x: 340, y: 380},
+    {name: 'rabbit', x: 420, y: 380}
+  ],
+  greenhouse: [
+    {name: 'duck', x: 360, y: 420},
+    {name: 'rabbit', x: 440, y: 420}
+  ],
+  picnic: [
+    {name: 'duck', x: 350, y: 460},
+    {name: 'rabbit', x: 430, y: 460}
+  ],
+  pond: [
+    {name: 'duck', x: 300, y: 400},
+    {name: 'rabbit', x: 380, y: 400}
+  ]
+};
 
 function preloadScenes() {
   scenes.farmMap = loadImage('assets/images/scenes/map.png');
@@ -39,6 +58,19 @@ function setupScenes() {
 
 function drawScene(scene) {
   image(scenes[scene], 0, 0, width, height);
+}
+
+// Draw characters for the given scene using the sceneCharacters map
+function drawSceneCharacters(scene) {
+  const entries = sceneCharacters[scene];
+  if (!entries) return;
+  entries.forEach(info => {
+    const char = characters[info.name];
+    if (char) {
+      const s = info.scale !== undefined ? info.scale : 0.35;
+      char.display(info.x, info.y, s);
+    }
+  });
 }
 
 function handleSceneClicks(mx, my) {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,9 +1,10 @@
 let currentScene = 'farmMap';
-let duck, rabbit, duckRabbitIcon;
+let characters = {};
+let duckRabbitIcon;
 
 function preload() {
-  duck = new Character('duck');
-  rabbit = new Character('rabbit');
+  characters.duck = new Character('duck');
+  characters.rabbit = new Character('rabbit');
   duckRabbitIcon = loadImage('assets/images/icons/duck-rabbit.png');
   preloadScenes();
   preloadLetters();
@@ -18,8 +19,9 @@ function draw() {
   background(220);
   drawScene(currentScene); // from scenes.js
   drawLetters(currentScene); // from letters.js
-  duck.display();
-  rabbit.display();
+  if (currentScene !== 'farmMap' && !currentScene.startsWith('barn')) {
+    drawSceneCharacters(currentScene);
+  }
   image(duckRabbitIcon, width - 70, 10, 60, 60);
 }
 


### PR DESCRIPTION
## Summary
- create a `sceneCharacters` map describing where Duck and Rabbit appear in certain scenes
- adjust the `Character` class to support position arguments and scaling (default 35%)
- draw characters using `drawSceneCharacters` only for non-map and non-barn scenes

## Testing
- `git status --short`