### PR TITLE
Implement continue button and scene order

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,5 +12,6 @@
   <script src="js/sceneCharacters.js"></script>
   <script src="js/scenes.js"></script>
   <script src="js/letters.js"></script>
+  <button id="continueBtn">Continue</button>
 </body>
 </html>

--- a/js/letters.js
+++ b/js/letters.js
@@ -209,12 +209,31 @@ function preloadLetters() {
     question: 'When do you feel full of zest?',
     x: 560, y: 520
   });
+
+  const placeholderScenes = [
+    'barn','barnInside','bench','dogHouse','donkey','field','flowers',
+    'flowers2','garden','grass','greenhouseInside','loft','loftEntrance',
+    'mirror','pond2','radioRoom','studio'
+  ];
+  placeholderScenes.forEach(s => {
+    letters.push({
+      scene: s,
+      letter: '?',
+      concept: 'Coming Soon',
+      description: '',
+      question: '',
+      x: 400, y: 300
+    });
+  });
 }
 
 function handleLetterClicks(mx, my) {
   letters.forEach(l => {
     if (l.scene === currentScene && dist(mx, my, l.x, l.y) < 20) {
       showLetterInfo(l);
+      if (typeof continueBtn !== 'undefined') {
+        continueBtn.style.display = 'block';
+      }
     }
   });
 }

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -13,9 +13,9 @@ function preloadScenes() {
   scenes.field = loadImage('assets/images/scenes/field.png');
   scenes.flowers = loadImage('assets/images/scenes/flowers.png');
   scenes.flowers2 = loadImage('assets/images/scenes/flowers2.png');
-  scenes.garden = loadImage('assets/images/scenes/garden.png');
+  scenes.garden = loadImage('assets/images/scenes/vegetables.png');
   scenes.grass = loadImage('assets/images/scenes/grass.png');
-  scenes.greenhouseInside = loadImage('assets/images/scenes/greenhouse-inside.png');
+  scenes.greenhouseInside = loadImage('assets/images/scenes/greenhouseInside.png');
   scenes.loft = loadImage('assets/images/scenes/loft.png');
   scenes.loftEntrance = loadImage('assets/images/scenes/loftEntrance.png');
   scenes.mirror = loadImage('assets/images/scenes/mirror.png');
@@ -24,7 +24,7 @@ function preloadScenes() {
   scenes.pond2 = loadImage('assets/images/scenes/pond2.png');
   scenes.radioRoom = loadImage('assets/images/scenes/radioRoom.png');
   scenes.studio = loadImage('assets/images/scenes/studio.png');
-  scenes.swingScene = loadImage('assets/images/scenes/swingScene.png');
+  scenes.swingScene = loadImage('assets/images/scenes/swing.png');
   scenes.tunnel = loadImage('assets/images/scenes/tunnel.png');
 }
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -2,6 +2,18 @@ let currentScene = 'farmMap';
 let duck, rabbit, donkey;
 let duckRabbitIcon, barnIcon;
 
+const orderedScenes = [
+  'farmMap',
+  'picnic', 'tunnel', 'pond', 'batCave', 'greenhouse', 'batCave',
+  'swing', 'swing2', 'greenhouse', 'batCave', 'farmMap',
+  'greenhouse', 'batCave', 'farmMap', 'greenhouse',
+  'batCave', 'farmMap', 'farmMap', 'greenhouse', 'batCave',
+  'farmMap', 'greenhouse', 'batCave', 'farmMap',
+  'greenhouse', 'farmMap'
+];
+let sceneIndex = 0;
+let continueBtn;
+
 function preload() {
   duck = new Character('duck');
   rabbit = new Character('rabbit');
@@ -21,6 +33,9 @@ function preload() {
 function setup() {
   createCanvas(800, 600);
   setupScenes();
+  continueBtn = document.getElementById('continueBtn');
+  continueBtn.addEventListener('click', advanceScene);
+  continueBtn.style.display = currentScene === 'farmMap' ? 'none' : 'block';
 }
 
 function draw() {
@@ -60,4 +75,18 @@ function mousePressed() {
 
 function showAdvice() {
   alert("Duck-Rabbit says: Think about things from a different perspective!");
+}
+
+function advanceScene() {
+  sceneIndex++;
+  if (sceneIndex >= orderedScenes.length) {
+    continueBtn.style.display = 'none';
+    return;
+  }
+  currentScene = orderedScenes[sceneIndex];
+  if (currentScene === 'farmMap') {
+    continueBtn.style.display = 'none';
+  } else {
+    continueBtn.style.display = 'none';
+  }
 }

--- a/style.css
+++ b/style.css
@@ -7,6 +7,8 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   background-color: #f5f9ff;
 
+  position: relative;
+
   /* Center the canvas within the page */
   display: flex;
   justify-content: center;
@@ -19,4 +21,15 @@ canvas {
   border: 2px solid #333;
   background-color: #fff;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+#continueBtn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 10px 20px;
+  font-size: 18px;
+  display: none;
+  z-index: 10;
 }


### PR DESCRIPTION
## Summary
- add Continue button to HTML
- style Continue button overlay
- add ordered scene list, scene progression tracking, and continue logic
- hide button on map and show it when a letter is found
- add placeholder letters for unused scenes
- correct several scene image paths

## Testing
- `npm test` *(fails: package.json not found)*