### PR TITLE
Handle missing character images gracefully

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -12,8 +12,19 @@ class Character {
   }
 
   preloadImages() {
+    const placeholder = `assets/images/${this.name}/placeholder.png`;
     this.states.forEach(state => {
-      this.images[state] = loadImage(`assets/images/${this.name}/${state}.png`);
+      const path = `assets/images/${this.name}/${state}.png`;
+      this.images[state] = loadImage(
+        path,
+        img => {
+          this.images[state] = img;
+        },
+        () => {
+          console.warn(`Missing ${path}, falling back to placeholder`);
+          this.images[state] = loadImage(placeholder);
+        }
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- add fallback in `Character.preloadImages()` so missing images use `placeholder.png`

## Testing
- `npm test`