### PR TITLE
Add orange cat to donkey scene only

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -19,6 +19,7 @@ defaultScenes.forEach(scene => {
 
 sceneCharacters.barn.push('donkey');
 sceneCharacters.donkey.push('donkey');
+sceneCharacters.donkey.push('orangecat');
 
 // Dog appears only in the dogHouse, barn, and farmMap scenes
 ['dogHouse', 'barn', 'farmMap'].forEach(scene => {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,5 +1,5 @@
 let currentScene = 'farmMap';
-let duck, rabbit, donkey, dog, sheep, sheepbaby, owl, graytortiecat, chick;
+let duck, rabbit, donkey, dog, sheep, sheepbaby, owl, graytortiecat, orangecat, chick;
 let duckRabbitIcon, barnIcon;
 
 const orderedScenes = [
@@ -46,6 +46,12 @@ function preload() {
   graytortiecat = new Character('graytortiecat', []);
   graytortiecat.images['idle'] = loadImage('assets/images/graytortiecat/default.png');
   graytortiecat.state = 'idle';
+
+  orangecat = new Character('orangecat', []);
+  orangecat.images['idle'] = loadImage('assets/images/orangecat/default.png');
+  orangecat.state = 'idle';
+  orangecat.x = 450;
+  orangecat.y = 430;
 
   chick = new Character('chick', []);
   chick.images['idle'] = loadImage('assets/images/chick/default.png');


### PR DESCRIPTION
## Summary
- include new `orangecat` character setup in `sketch.js`
- show the orange cat during the donkey scene via `sceneCharacters.js`

## Testing
- `npm test`