### PR TITLE
Add start and vegetables scenes

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -3,8 +3,8 @@
 const defaultScenes = [
   'farmMap','picnic','tunnel','pond','cave','greenhouse','swing','swing2',
   'barn','barnInside','bench','dogHouse','donkey','field','flowers','flowers2',
-  'garden','vegetables2','grass','greenhouseInside','loft','loftEntrance','mirror','pond2',
-  'radioRoom','studio'
+  'garden','vegetables','vegetables2','grass','greenhouseInside','loft','loftEntrance','mirror','pond2',
+  'radioRoom','studio','start'
 ];
 
 const sceneCharacters = {};

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -27,6 +27,8 @@ function preloadScenes() {
   scenes.studio = loadImage('assets/images/scenes/studio.png');
   scenes.swing = loadImage('assets/images/scenes/swing.png');
   scenes.swing2 = loadImage('assets/images/scenes/swing2.png');
+  scenes.start = loadImage('assets/images/scenes/start.png');
+  scenes.vegetables = loadImage('assets/images/scenes/vegetables.png');
   scenes.tunnel = loadImage('assets/images/scenes/tunnel.png');
 }
 


### PR DESCRIPTION
## Summary
- load start and vegetables scene images
- include `start` and `vegetables` in default scenes list

## Testing
- `npm test`