### PR TITLE
Enable scene-specific character placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ philosophygame/
 └── style.css         # Styling
 ```
 
+### Scene-specific character settings
+
+The file `js/sceneCharacters.js` exports an optional `sceneCharacterSettings`
+object. Use it to override where a character appears and how large it is in a
+given scene:
+
+```javascript
+sceneCharacterSettings["barn"] = {
+  donkey: { x: 340, y: 400, size: 140 }
+};
+```
+
+Any properties you specify will temporarily replace the character's default
+`x`, `y` and `size` values while that scene is drawn.
+
 ## 🤝 Contribution
 
 Suggestions and contributions are welcome! Feel free to open issues or submit pull requests to help enhance the game.

--- a/js/characters.js
+++ b/js/characters.js
@@ -1,10 +1,14 @@
 class Character {
-  constructor(name, states) {
+  constructor(name, states, size = 100) {
     this.name = name;
     this.images = {};
     this.state = 'idle';
     this.x = random(100, 700);
     this.y = random(300, 500);
+    this.size = size;
+    this.baseX = this.x;
+    this.baseY = this.y;
+    this.baseSize = size;
     this.states = Array.isArray(states) && states.length ? states : [];
     if (!this.states.includes('idle')) {
       this.states.unshift('idle');
@@ -32,7 +36,19 @@ class Character {
   }
 
   display() {
-    image(this.images[this.state], this.x, this.y, 100, 100);
+    image(this.images[this.state], this.x, this.y, this.size, this.size);
+  }
+
+  reset() {
+    this.x = this.baseX;
+    this.y = this.baseY;
+    this.size = this.baseSize;
+  }
+
+  initBase() {
+    this.baseX = this.x;
+    this.baseY = this.y;
+    this.baseSize = this.size;
   }
 
   setState(newState) {

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -8,6 +8,9 @@ const defaultScenes = [
 ];
 
 const sceneCharacters = {};
+// Optional position/size overrides per scene
+// sceneCharacterSettings[scene][character] = {x, y, size}
+const sceneCharacterSettings = {};
 
 defaultScenes.forEach(scene => {
   sceneCharacters[scene] = ['duck', 'rabbit'];
@@ -41,4 +44,5 @@ sceneCharacters.barnInside.push('bat');
 
 if (typeof window !== 'undefined') {
   window.sceneCharacters = sceneCharacters;
+  window.sceneCharacterSettings = sceneCharacterSettings;
 }

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -76,6 +76,17 @@ function drawSceneCharacters(scene) {
   chars.forEach(name => {
     const charObj = window[name];
     if (charObj && typeof charObj.display === 'function') {
+      if (typeof charObj.reset === 'function') {
+        charObj.reset();
+      }
+      const overrides =
+        sceneCharacterSettings[scene] &&
+        sceneCharacterSettings[scene][name];
+      if (overrides) {
+        if (overrides.x !== undefined) charObj.x = overrides.x;
+        if (overrides.y !== undefined) charObj.y = overrides.y;
+        if (overrides.size !== undefined) charObj.size = overrides.size;
+      }
       charObj.display();
     }
   });

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -31,12 +31,14 @@ function preload() {
   donkey.state = 'idle';
   donkey.x = 380;
   donkey.y = 420;
+  donkey.initBase();
 
   dog = new Character('dog', ['happy', 'sad']);
   dog.images['idle'] = loadImage('assets/images/dog/default.png');
   dog.state = 'idle';
   dog.x = 620;
   dog.y = 440;
+  dog.initBase();
 
   sheep = new Character('sheep', [
     'forward-talking',
@@ -49,12 +51,14 @@ function preload() {
   sheep.state = 'idle';
   sheep.x = 460;
   sheep.y = 420;
+  sheep.initBase();
 
   sheepbaby = new Character('sheepbaby', ['slight-right']);
   sheepbaby.images['idle'] = loadImage('assets/images/sheepbaby/default.png');
   sheepbaby.state = 'idle';
   sheepbaby.x = 520;
   sheepbaby.y = 440;
+  sheepbaby.initBase();
 
   owl = new Character('owl', [
     'eyes-closed-mouth-open',
@@ -79,6 +83,7 @@ function preload() {
   orangecat.state = 'idle';
   orangecat.x = 450;
   orangecat.y = 430;
+  orangecat.initBase();
 
   chick = new Character('chick', ['eggcited', 'in-egg-closed', 'in-egg-open']);
   chick.images['idle'] = loadImage('assets/images/chick/default.png');
@@ -90,6 +95,7 @@ function preload() {
   bat.state = 'idle';
   bat.x = 420;
   bat.y = 180;
+  bat.initBase();
   // Optional: set x/y coordinates
 
   pig = {
@@ -103,9 +109,23 @@ function preload() {
     lastSwitch: 0,
     x: 360,
     y: 420,
+    size: 100,
+    baseX: 360,
+    baseY: 420,
+    baseSize: 100,
     display() {
       this.update();
-      image(this.images[this.current], this.x, this.y, 100, 100);
+      image(this.images[this.current], this.x, this.y, this.size, this.size);
+    },
+    reset() {
+      this.x = this.baseX;
+      this.y = this.baseY;
+      this.size = this.baseSize;
+    },
+    initBase() {
+      this.baseX = this.x;
+      this.baseY = this.y;
+      this.baseSize = this.size;
     },
     update() {
       if ((currentScene === 'farmMap' || currentScene === 'swing') && !letterGFound) {
@@ -127,6 +147,7 @@ function preload() {
       }
     }
   };
+  pig.initBase();
 
   duckRabbitIcon = loadImage('assets/images/icons/duck-rabbit.png');
   barnIcon = loadImage('assets/images/icons/barndefault.png');


### PR DESCRIPTION
## Summary
- extend `Character` with base position/size fields
- allow per-scene overrides through `sceneCharacterSettings`
- reset characters before applying overrides when drawing scenes
- update pig object to support the new behaviour
- document usage of `sceneCharacterSettings`

## Testing
- `npm test`