### PR TITLE
Implement barn exploration flow

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -55,8 +55,8 @@ function drawScene(scene) {
 }
 
 function handleSceneClicks(mx, my) {
+  let clicked = false;
   if (currentScene === 'farmMap') {
-    let clicked = false;
     scenes.interactiveAreas.forEach(area => {
       const withinArea =
         mx > area.x &&
@@ -73,6 +73,10 @@ function handleSceneClicks(mx, my) {
         my <= area.y + iconSize;
       if (withinArea || withinIcon) {
         currentScene = area.name;
+        if (typeof orderedScenes !== 'undefined') {
+          const idx = orderedScenes.indexOf(area.name);
+          if (idx !== -1) sceneIndex = idx;
+        }
         clicked = true;
       }
     });
@@ -84,6 +88,9 @@ function handleSceneClicks(mx, my) {
 
     if (typeof dog !== 'undefined' && withinChar(dog)) {
       currentScene = 'dogHouse';
+      if (typeof orderedScenes !== 'undefined') {
+        sceneIndex = orderedScenes.indexOf('dogHouse');
+      }
       return;
     }
 
@@ -92,13 +99,42 @@ function handleSceneClicks(mx, my) {
       typeof sheepbaby !== 'undefined' && withinChar(sheepbaby)
     ) {
       currentScene = 'field';
+      if (typeof orderedScenes !== 'undefined') {
+        sceneIndex = orderedScenes.indexOf('field');
+      }
       return;
     }
 
     if (typeof pig !== 'undefined' && withinChar(pig)) {
       currentScene = 'swing';
+      if (typeof orderedScenes !== 'undefined') {
+        sceneIndex = orderedScenes.indexOf('swing');
+      }
       return;
     }
+  }
+  if (currentScene === 'barnInside') {
+    const areas = [
+      {name: 'studio', x: 250, y: 270, w: 100, h: 100},
+      {name: 'mirror', x: 230, y: 110, w: 100, h: 100},
+      {name: 'radioRoom', x: 150, y: 330, w: 100, h: 100},
+      {name: 'loftEntrance', x: 380, y: 360, w: 100, h: 100}
+    ];
+    areas.forEach(area => {
+      const within =
+        mx >= area.x && mx <= area.x + area.w &&
+        my >= area.y && my <= area.y + area.h;
+      if (within) {
+        currentScene = area.name;
+        if (area.name === 'loftEntrance') {
+          sceneIndex = orderedScenes.indexOf('loftEntrance');
+        } else {
+          sceneIndex = orderedScenes.indexOf('barnInside');
+        }
+        clicked = true;
+      }
+    });
+    if (clicked) return;
   }
 }
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -12,7 +12,10 @@ let picnicReached = false,
 const orderedScenes = [
   'start', 'bench', 'pond', 'pond2', 'flowers', 'grass', 'flowers2',
   'greenhouse', 'greenhouseInside', 'vegetables', 'tunnel', 'cave',
-  'vegetables2', 'picnic', 'farmMap'
+  'vegetables2', 'picnic', 'farmMap',
+  // post map flow
+  'swing', 'swing2', 'dogHouse', 'field', 'barn',
+  'barnInside', 'loftEntrance', 'loft', 'barnInside'
 ];
 let sceneIndex = 0;
 let continueBtn;
@@ -195,12 +198,14 @@ function mousePressed() {
   if (currentScene === 'barn') {
     if (mouseX > donkey.x && mouseX < donkey.x + 100 && mouseY > donkey.y && mouseY < donkey.y + 100) {
       currentScene = 'donkey';
+      sceneIndex = orderedScenes.indexOf('barn');
       return;
     }
   }
   if (currentScene === 'donkey') {
     if (mouseX >= 10 && mouseX <= 60 && mouseY >= 10 && mouseY <= 60) {
       currentScene = 'barn';
+      sceneIndex = orderedScenes.indexOf('barn');
       return;
     }
   }
@@ -224,15 +229,23 @@ function showAdvice() {
 }
 
 function advanceScene() {
+  if (currentScene === 'donkey') {
+    currentScene = 'barn';
+    sceneIndex = orderedScenes.indexOf('barn');
+    continueBtn.style.display = 'none';
+    return;
+  }
+  if (['studio','mirror','radioRoom'].includes(currentScene)) {
+    currentScene = 'barnInside';
+    sceneIndex = orderedScenes.indexOf('barnInside');
+    continueBtn.style.display = 'none';
+    return;
+  }
   sceneIndex++;
   if (sceneIndex >= orderedScenes.length) {
     continueBtn.style.display = 'none';
     return;
   }
   currentScene = orderedScenes[sceneIndex];
-  if (currentScene === 'farmMap') {
-    continueBtn.style.display = 'none';
-  } else {
-    continueBtn.style.display = 'none';
-  }
+  continueBtn.style.display = currentScene === 'farmMap' ? 'none' : 'none';
 }


### PR DESCRIPTION
## Summary
- allow post-map gameplay with new ordered scenes
- track scene index when clicking map characters
- add barn interior interactive areas
- return from optional scenes back to main path

## Testing
- `npm test`