### PR TITLE
Enable tray swap

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -53,6 +53,9 @@ sceneCharacters.barnInside.push('bat');
   sceneCharacters[scene].push('pig');
 });
 
+sceneCharacters.greenhouseInside.push('trayA');
+sceneCharacters.greenhouseInside.push('trayB');
+
 // Use combined duck/rabbit swing animation in swing2
 sceneCharacters['swing2'] = sceneCharacters['swing2'].filter(c => c !== 'duck' && c !== 'rabbit');
 sceneCharacters['swing2'].push('duckRabbitSwing');

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -113,6 +113,38 @@ function handleSceneClicks(mx, my) {
       return;
     }
   }
+  if (currentScene === 'greenhouseInside') {
+    const withinTrayA =
+      mx >= trayA.x && mx <= trayA.x + trayA.size &&
+      my >= trayA.y && my <= trayA.y + trayA.size;
+    const withinTrayB =
+      mx >= trayB.x && mx <= trayB.x + trayB.size &&
+      my >= trayB.y && my <= trayB.y + trayB.size;
+    if (withinTrayA && trayOnTable !== 'trayA') {
+      const tX = trayA.baseX;
+      const tY = trayA.baseY;
+      trayA.baseX = trayB.baseX;
+      trayA.baseY = trayB.baseY;
+      trayB.baseX = tX;
+      trayB.baseY = tY;
+      trayOnTable = 'trayA';
+      trayA.reset();
+      trayB.reset();
+      clicked = true;
+    } else if (withinTrayB && trayOnTable !== 'trayB') {
+      const tX = trayA.baseX;
+      const tY = trayA.baseY;
+      trayA.baseX = trayB.baseX;
+      trayA.baseY = trayB.baseY;
+      trayB.baseX = tX;
+      trayB.baseY = tY;
+      trayOnTable = 'trayB';
+      trayA.reset();
+      trayB.reset();
+      clicked = true;
+    }
+    if (clicked) return;
+  }
   if (currentScene === 'barnInside') {
     const areas = [
       {name: 'studio', x: 250, y: 270, w: 100, h: 100},

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -2,13 +2,14 @@ let currentScene = 'start';
 // Declare character variables with var so they become properties on the global
 // window object. drawSceneCharacters in scenes.js accesses characters via
 // window[name], so using var ensures they are available there.
-var duck, rabbit, donkey, dog, sheep, sheepbaby, owl, graytortiecat, orangecat, chick, bat, pig, duckRabbitSwing;
+var duck, rabbit, donkey, dog, sheep, sheepbaby, owl, graytortiecat, orangecat, chick, bat, pig, duckRabbitSwing, trayA, trayB;
 let letterGFound = false;
 let letterHFound = false;
 let duckRabbitIcon, barnIcon;
 let picnicReached = false,
     mapIcon;
 let mapUnlocked = false;
+let trayOnTable = 'trayB';
 
 // Movement variables for the duck in pond2
 let duckTargetX = null;
@@ -206,6 +207,54 @@ function preload() {
     }
   };
   duckRabbitSwing.initBase();
+
+  trayA = {
+    images: { default: loadImage('assets/images/trays/trayA.png') },
+    x: 500,
+    y: 420,
+    size: 80,
+    baseX: 500,
+    baseY: 420,
+    baseSize: 80,
+    display() {
+      image(this.images.default, this.x, this.y, this.size, this.size);
+    },
+    reset() {
+      this.x = this.baseX;
+      this.y = this.baseY;
+      this.size = this.baseSize;
+    },
+    initBase() {
+      this.baseX = this.x;
+      this.baseY = this.y;
+      this.baseSize = this.size;
+    }
+  };
+  trayA.initBase();
+
+  trayB = {
+    images: { default: loadImage('assets/images/trays/trayB.png') },
+    x: 360,
+    y: 420,
+    size: 80,
+    baseX: 360,
+    baseY: 420,
+    baseSize: 80,
+    display() {
+      image(this.images.default, this.x, this.y, this.size, this.size);
+    },
+    reset() {
+      this.x = this.baseX;
+      this.y = this.baseY;
+      this.size = this.baseSize;
+    },
+    initBase() {
+      this.baseX = this.x;
+      this.baseY = this.y;
+      this.baseSize = this.size;
+    }
+  };
+  trayB.initBase();
 
   duckRabbitIcon = loadImage('assets/images/icons/duck-rabbit.png');
   barnIcon = loadImage('assets/images/icons/barndefault.png');


### PR DESCRIPTION
## Summary
- add tray objects to global list
- only show trays in the greenhouseInside scene
- allow clicking trays to swap which one is on the table

## Testing
- `npm test`