### PR TITLE
Switch to mouth closed idle states

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -11,15 +11,22 @@ class Character {
     this.baseY = this.y;
     this.baseSize = size;
     this.states = Array.isArray(states) && states.length ? states.slice() : [];
+
+    // Ensure base states are always available
     if (!this.states.includes('idle')) {
       this.states.unshift('idle');
     }
+    if (!this.states.includes('default')) {
+      this.states.unshift('default');
+    }
+
     // Always attempt to preload a mouth-closed image so characters can
     // revert to it when not speaking. If the image doesn't exist, the
     // fallback in preloadImages will load the default instead.
     if (!this.states.includes('mouth-closed')) {
       this.states.push('mouth-closed');
     }
+
     this.preloadImages();
   }
 
@@ -56,6 +63,15 @@ class Character {
     this.baseX = this.x;
     this.baseY = this.y;
     this.baseSize = this.size;
+  }
+
+  // Allows new poses to be added on the fly so scenes can introduce
+  // additional movements or expressions later.
+  addState(name, path) {
+    if (this.states.includes(name)) return;
+    this.states.push(name);
+    const imgPath = path || `assets/images/${this.name}/${name}.png`;
+    this.images[name] = loadImage(imgPath);
   }
 
   setState(newState) {

--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -12,8 +12,10 @@ function setCharacterState(name, speaking, pose) {
   const ch = window[name];
   if (!ch || typeof ch.setState !== 'function') return;
   if (speaking) {
+    // Use the default talking image unless a specific pose is provided
     ch.setState(pose || 'default');
   } else {
+    // When done speaking, return to the neutral mouth-closed pose
     if (ch.states.includes('mouth-closed')) {
       ch.setState('mouth-closed');
     } else if (ch.states.includes('closed')) {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -108,9 +108,8 @@ function preload() {
   chick.images['idle'] = loadImage('assets/images/chick/default.png');
   chick.state = 'mouth-closed';
 
-  bat = new Character('bat', ['wings-flap', 'mouth-closed']);
+  bat = new Character('bat', ['mouth-closed']);
   bat.images['idle'] = loadImage('assets/images/bat/default.png');
-  bat.images['flap'] = loadImage('assets/images/bat/wings-flap.png');
   bat.state = 'mouth-closed';
   bat.x = 420;
   bat.y = 180;


### PR DESCRIPTION
## Summary
- ensure characters always include default and mouth-closed poses
- add `addState` helper to Character for future animations
- show default pose while speaking and revert to mouth-closed afterward
- update bat setup to use available images

## Testing
- `npm run check-assets`
- `npm test`
