### PR TITLE
Fix bench dialogue flow and add initial instructions

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -1,5 +1,13 @@
 const dialogues = {
-  bench: [
+  start: [
+    { speaker: 'duck', text: 'Welcome to the Duck-Rabbit Farm!' },
+    { speaker: 'rabbit', text: 'Click Continue and look for letters to learn more.' }
+  ],
+  benchIntro: [
+    { speaker: 'duck', text: 'See those letters around the farm? Try clicking on them!' },
+    { speaker: 'rabbit', text: 'Each one will tell us something new.' }
+  ],
+  benchRest: [
     { speaker: 'duck', text: 'Take a seat, Rabbit. Let\'s rest for a bit.' },
     { speaker: 'rabbit', text: 'Good idea! We still have many letters to find.' }
   ]

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -310,10 +310,17 @@ function draw() {
   drawSceneCharacters(currentScene); // from scenes.js
   if (
     !isDialogueActive() &&
-    currentScene === 'bench' &&
-    !dialoguesPlayed['bench']
+    currentScene === 'start' &&
+    !dialoguesPlayed['start']
   ) {
-    playDialogue('bench');
+    playDialogue('start');
+  }
+  if (!isDialogueActive() && currentScene === 'bench') {
+    if (!dialoguesPlayed['benchIntro']) {
+      playDialogue('benchIntro');
+    } else if (mapUnlocked && !dialoguesPlayed['benchRest']) {
+      playDialogue('benchRest');
+    }
   }
   if (
     !isDialogueActive() &&


### PR DESCRIPTION
## Summary
- add a short dialogue for the start screen
- split bench dialogue into an intro and a later rest conversation
- trigger the new dialogues from `draw()`

## Testing
- `npm run check-assets`
- `npm test`