### PR TITLE
Add back navigation and letter hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Welcome to the **Duck-Rabbit Philosophy Farm**, an interactive, educational game
 * Discover hidden letters scattered throughout the scenes. Each one is a colorful image from the `assets/images/letters` folder.
 * When a letter is clicked, it slides to the bottom of the screen and lines up with the others.
 * Each letter reveals a philosophical concept, a friendly explanation, and engaging questions.
-* Click on the Duck-Rabbit icon anytime for helpful advice or hints. After you find all 26 letters, the icon congratulates you.
+* Click on the Duck-Rabbit icon anytime for helpful advice or hints. After you find all 26 letters, the icon congratulates you and any unfound letters in the current scene briefly grow larger to help you spot them.
 * Once you reach the picnic area, a map icon appears in the top-left corner. Click it to return to the farm map.
+* Use the **Back** button to return to the previous scene whenever you like.
 
 ## 🌟 Key Features
 

--- a/index.html
+++ b/index.html
@@ -15,5 +15,6 @@
   <script src="js/dialogue.js"></script>
   <div id="dialogueBox" aria-live="polite"></div>
   <button id="continueBtn" aria-label="Continue">Continue</button>
+  <button id="backBtn" aria-label="Back">Back</button>
 </body>
 </html>

--- a/js/letters.js
+++ b/js/letters.js
@@ -219,6 +219,7 @@ function preloadLetters() {
     }
     l.found = false;
     l.size = 32;
+    l.baseSize = 32;
   });
 }
 
@@ -347,5 +348,16 @@ function allLettersFoundForScene(scene) {
   return letters
     .filter(l => l.scene === scene)
     .every(l => l.found);
+}
+
+function highlightMissingLetters(scene) {
+  letters.forEach(l => {
+    if (l.scene === scene && !l.found) {
+      l.size = l.baseSize * 2;
+      setTimeout(() => {
+        l.size = l.baseSize;
+      }, 1000);
+    }
+  });
 }
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -31,6 +31,8 @@ const orderedScenes = [
 ];
 let sceneIndex = 0;
 let continueBtn;
+let backBtn;
+let sceneHistory = [currentScene];
 
 function preload() {
   duck = new Character('duck', [
@@ -275,6 +277,9 @@ function setup() {
   // Start with the continue button hidden; it will be shown
   // at the appropriate time by playDialogue
   continueBtn.style.display = 'none';
+  backBtn = document.getElementById('backBtn');
+  backBtn.addEventListener('click', goBackScene);
+  backBtn.style.display = 'none';
   dialogueBox = document.getElementById('dialogueBox');
 }
 
@@ -305,8 +310,11 @@ function draw() {
       }
     }
   }
+  if (sceneHistory[sceneHistory.length - 1] !== currentScene) {
+    sceneHistory.push(currentScene);
+  }
+  backBtn.style.display = sceneHistory.length > 1 ? 'block' : 'none';
   drawScene(currentScene); // from scenes.js
-  drawLetters(currentScene); // from letters.js
   drawSceneCharacters(currentScene); // from scenes.js
   if (
     !isDialogueActive() &&
@@ -352,6 +360,7 @@ function draw() {
     image(mapIcon, 10, 10, 50, 50);
   }
   image(duckRabbitIcon, width - 70, 10, 60, 60);
+  drawLetters(currentScene); // draw letters on top
 }
 
 function mousePressed() {
@@ -396,6 +405,7 @@ function showAdvice() {
   } else {
     alert("Duck-Rabbit says: Think about things from a different perspective!");
   }
+  highlightMissingLetters(currentScene);
 }
 
 function advanceScene() {
@@ -420,6 +430,16 @@ function advanceScene() {
   // Hide the button immediately after switching scenes; it will be
   // displayed again when the next dialogue finishes.
   continueBtn.style.display = 'none';
+}
+
+function goBackScene() {
+  if (sceneHistory.length > 1) {
+    sceneHistory.pop();
+    currentScene = sceneHistory[sceneHistory.length - 1];
+    const idx = orderedScenes.indexOf(currentScene);
+    if (idx !== -1) sceneIndex = idx;
+    continueBtn.style.display = 'none';
+  }
 }
 
 function keyPressed() {

--- a/style.css
+++ b/style.css
@@ -45,6 +45,21 @@ canvas {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
 }
 
+#backBtn {
+  position: absolute;
+  top: 10px;
+  left: 70px;
+  padding: 8px 16px;
+  font-size: 18px;
+  background: #ffcc00;
+  color: #333;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  display: none;
+  z-index: 10;
+}
+
 #dialogueBox {
   position: absolute;
   bottom: 20px;


### PR DESCRIPTION
## Summary
- add Back button to return to the previous scene
- keep letters above characters and icons
- highlight missing letters when the Duck-Rabbit icon is clicked
- document new features in README

## Testing
- `npm test`
- `npm run check-assets`
