### PR TITLE
Fix barnInside flow

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -166,7 +166,13 @@ function playDialogue(scene, callback) {
       box.onclick = null;
       dialogueActive = false;
       dialoguesPlayed[scene] = true;
-      if (continueBtn) continueBtn.style.display = 'block';
+      if (continueBtn) {
+        if (scene === 'barnInside') {
+          continueBtn.style.display = 'none';
+        } else {
+          continueBtn.style.display = 'block';
+        }
+      }
       if (callback) callback();
       return;
     }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -421,6 +421,10 @@ function advanceScene() {
     continueBtn.style.display = 'none';
     return;
   }
+  if (currentScene === 'barnInside') {
+    continueBtn.style.display = 'none';
+    return;
+  }
   sceneIndex++;
   if (sceneIndex >= orderedScenes.length) {
     continueBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- stop the Continue button from showing after the `barnInside` dialogue
- ignore Continue clicks when in `barnInside`

## Testing
- `npm test`
- `npm run check-assets`