### PR TITLE
Handle pond2 interaction flow

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -167,7 +167,7 @@ function playDialogue(scene, callback) {
       dialogueActive = false;
       dialoguesPlayed[scene] = true;
       if (continueBtn) {
-        if (scene === 'barnInside') {
+        if (scene === 'barnInside' || scene === 'pond2') {
           continueBtn.style.display = 'none';
         } else {
           continueBtn.style.display = 'block';

--- a/js/letters.js
+++ b/js/letters.js
@@ -250,6 +250,10 @@ function handleLetterClicks(mx, my) {
           l.x = l.bottomX;
           l.y = l.bottomY;
           lettersFoundCount++;
+          if (l.letter === 'D' && l.scene === 'pond2') {
+            const btn = document.getElementById('continueBtn');
+            if (btn) btn.style.display = 'block';
+          }
         }
         if (l.letter === 'G') {
           letterGFound = true;
@@ -296,6 +300,10 @@ function checkDuckLetterCollision(duck) {
         l.x = l.bottomX;
         l.y = l.bottomY;
         lettersFoundCount++;
+        if (l.letter === 'D' && l.scene === 'pond2') {
+          const btn = document.getElementById('continueBtn');
+          if (btn) btn.style.display = 'block';
+        }
       }
       if (l.letter === 'G') {
         letterGFound = true;
@@ -322,6 +330,9 @@ function showLetterInfo(letter) {
 // Draw letter indicators for the current scene
 function drawLetters(scene) {
   letters.forEach(l => {
+    if (l.letter === 'D' && l.scene === 'pond2' && !dialoguesPlayed['pond2']) {
+      return;
+    }
     if (l.found) {
       if (l.img) {
         image(l.img, l.bottomX - l.size / 2, l.bottomY - l.size / 2, l.size, l.size);


### PR DESCRIPTION
## Summary
- delay drawing letter D until the pond2 dialogue completes
- keep the Continue button hidden after the pond2 dialogue
- reveal Continue when letter D is collected by clicking or duck collision

## Testing
- `npm run check-assets`
- `npm test`