### PR TITLE
Replay dialogue when returning to previous scene

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -330,7 +330,20 @@ function showLetterInfo(letter) {
 // Draw letter indicators for the current scene
 function drawLetters(scene) {
   letters.forEach(l => {
-    if (l.letter === 'D' && l.scene === 'pond2' && !dialoguesPlayed['pond2']) {
+    if (
+      l.scene === 'pond2' &&
+      l.letter === 'D' &&
+      currentScene === 'pond2' &&
+      isDialogueActive()
+    ) {
+      return;
+    }
+    if (
+      l.scene === 'bench' &&
+      !l.found &&
+      currentScene === 'bench' &&
+      isDialogueActive()
+    ) {
       return;
     }
     if (l.found) {
@@ -359,6 +372,10 @@ function allLettersFoundForScene(scene) {
   return letters
     .filter(l => l.scene === scene)
     .every(l => l.found);
+}
+
+function sceneHasLetters(scene) {
+  return letters.some(l => l.scene === scene);
 }
 
 function highlightMissingLetters(scene) {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -471,6 +471,19 @@ function goBackScene() {
     const idx = orderedScenes.indexOf(currentScene);
     if (idx !== -1) sceneIndex = idx;
     continueBtn.style.display = 'none';
+    if (currentScene === 'bench') {
+      const dlg = mapUnlocked ? 'benchRest' : 'benchIntro';
+      playDialogue(dlg);
+    } else if (currentScene === 'pond2') {
+      const letterD = letters.find(l => l.scene === 'pond2' && l.letter === 'D');
+      playDialogue('pond2', () => {
+        if (letterD && letterD.found) {
+          continueBtn.style.display = 'block';
+        }
+      });
+    } else if (sceneHasLetters(currentScene) && allLettersFoundForScene(currentScene)) {
+      playDialogue(currentScene);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- hide bench and pond2 letters while dialogue plays
- provide utility to check if a scene has letters
- replay scene dialogue when using the back button

## Testing
- `npm run check-assets`
- `npm test`
