### PR TITLE
Update greenhouse choice and map labels

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -39,8 +39,15 @@ const dialogues = {
     { speaker: 'duck', text: "Here's the greenhouse! Let's check out our seedlings." }
   ],
   greenhouseInside: [
-    { speaker: 'rabbit', text: 'Oh no, we must move the watering line! Should we save the tray with 2 plants, or the one with 10?' },
-    { speaker: 'duck', text: 'Interesting choice! Every decision counts.' }
+    { speaker: 'rabbit', text: 'Oh no, we must move the watering line! Should we save the tray with 2 plants, or the one with 10?' }
+  ],
+  greenhouseInside_trayA: [
+    { speaker: 'rabbit', text: 'Great choice! Now even more plants will get water.' },
+    { speaker: 'duck', text: 'Thanks for helping so many seedlings!' }
+  ],
+  greenhouseInside_trayB: [
+    { speaker: 'rabbit', text: 'Okay! We\'ll hand water the other tray tomorrow.' },
+    { speaker: 'duck', text: 'Every plant will get its turn to grow.' }
   ],
   vegetables: [
     { speaker: 'duck', text: "I'm getting hungry." },
@@ -167,7 +174,7 @@ function playDialogue(scene, callback) {
       dialogueActive = false;
       dialoguesPlayed[scene] = true;
       if (continueBtn) {
-        if (scene === 'barnInside' || scene === 'pond2') {
+        if (scene === 'barnInside' || scene === 'pond2' || scene === 'farmMap' || scene === 'greenhouseInside') {
           continueBtn.style.display = 'none';
         } else {
           continueBtn.style.display = 'block';

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -35,18 +35,14 @@ function preloadScenes() {
 function setupScenes() {
   // Define interactive areas on the farm map
   scenes.interactiveAreas = [
-    {name: 'cave', x: 100, y: 200, w: 150, h: 150},
-    {name: 'greenhouse', x: 300, y: 200, w: 150, h: 150},
-    // Additional areas
-    // Approximated coordinates based on map layout
-    {name: 'barn', x: 220, y: 160, w: 150, h: 150},
-    {name: 'bench', x: 180, y: 220, w: 120, h: 80},
-    {name: 'dogHouse', x: 310, y: 360, w: 120, h: 100},
-    // New interactive areas
-    {name: 'pond', x: 300, y: 420, w: 140, h: 120},
-    {name: 'pond2', x: 340, y: 240, w: 140, h: 120},
-    {name: 'vegetables', x: 280, y: 80, w: 120, h: 80},
-    {name: 'picnic', x: 420, y: 260, w: 140, h: 100}
+    {name: 'barn', label: 'barn', x: 220, y: 160, w: 150, h: 150},
+    {name: 'swing', label: 'swing', x: 360, y: 420, w: 140, h: 120},
+    {name: 'dogHouse', label: 'doghouse', x: 310, y: 360, w: 120, h: 100},
+    {name: 'bench', label: 'bench', x: 180, y: 220, w: 120, h: 80},
+    {name: 'pond', label: 'pond', x: 300, y: 420, w: 140, h: 120},
+    {name: 'greenhouse', label: 'greenhouse', x: 300, y: 200, w: 150, h: 150},
+    {name: 'picnic', label: 'picnic', x: 420, y: 260, w: 140, h: 100},
+    {name: 'vegetables', label: 'vegetables', x: 280, y: 80, w: 120, h: 80}
   ];
 }
 
@@ -63,15 +59,7 @@ function handleSceneClicks(mx, my) {
         mx < area.x + area.w &&
         my > area.y &&
         my < area.y + area.h;
-      const isIcon = ['pond', 'pond2', 'vegetables', 'picnic'].includes(area.name);
-      const iconSize = 40;
-      const withinIcon =
-        isIcon &&
-        mx >= area.x &&
-        mx <= area.x + iconSize &&
-        my >= area.y &&
-        my <= area.y + iconSize;
-      if (withinArea || withinIcon) {
+      if (withinArea) {
         currentScene = area.name;
         if (typeof orderedScenes !== 'undefined') {
           const idx = orderedScenes.indexOf(area.name);
@@ -130,6 +118,9 @@ function handleSceneClicks(mx, my) {
       trayOnTable = 'trayA';
       trayA.reset();
       trayB.reset();
+      if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayA']) {
+        playDialogue('greenhouseInside_trayA');
+      }
       clicked = true;
     } else if (withinTrayB && trayOnTable !== 'trayB') {
       const tX = trayA.baseX;
@@ -141,6 +132,9 @@ function handleSceneClicks(mx, my) {
       trayOnTable = 'trayB';
       trayA.reset();
       trayB.reset();
+      if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayB']) {
+        playDialogue('greenhouseInside_trayB');
+      }
       clicked = true;
     }
     if (clicked) return;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -370,11 +370,14 @@ function draw() {
     checkDuckLetterCollision(duck);
   }
   if (currentScene === 'farmMap') {
-    const iconSize = 40;
+    textAlign(CENTER, CENTER);
+    fill(0);
+    textSize(16);
     scenes.interactiveAreas.forEach(area => {
-      if (['pond', 'pond2', 'vegetables', 'picnic'].includes(area.name)) {
-        image(scenes[area.name], area.x, area.y, iconSize, iconSize);
-      }
+      const lx = area.labelX !== undefined ? area.labelX : area.x + area.w / 2;
+      const ly = area.labelY !== undefined ? area.labelY : area.y + area.h / 2;
+      const label = area.label || area.name;
+      text(label, lx, ly);
     });
   }
   if (currentScene === 'donkey') {


### PR DESCRIPTION
## Summary
- add tray-specific replies in greenhouse
- disable Continue on greenhouseInside and farm map dialogs
- add map text labels and remove map icons
- adjust interactive areas to match new labels
- trigger responses when clicking trayA or trayB

## Testing
- `npm run check-assets`