### PR TITLE
Delay dialogue until continue

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -1,5 +1,7 @@
 let letters = [];
 let lettersFoundCount = 0;
+let pendingDialogueScene = null;
+let letterContinueHandler = null;
 
 function preloadLetters() {
   letters.push({
@@ -267,7 +269,7 @@ function handleLetterClicks(mx, my) {
           allLettersFoundForScene(currentScene) &&
           !dialoguesPlayed[currentScene]
         ) {
-          playDialogue(currentScene);
+          showContinueForDialogue(currentScene);
         }
       };
 
@@ -317,7 +319,7 @@ function checkDuckLetterCollision(duck) {
         allLettersFoundForScene(currentScene) &&
         !dialoguesPlayed[currentScene]
       ) {
-        playDialogue(currentScene);
+        showContinueForDialogue(currentScene);
       }
     }
   });
@@ -422,5 +424,27 @@ function highlightMissingLetters(scene) {
       }, 1000);
     }
   });
+}
+
+function showContinueForDialogue(scene) {
+  const btn = document.getElementById('continueBtn');
+  if (!btn) return;
+  pendingDialogueScene = scene;
+  btn.style.display = 'block';
+  btn.removeEventListener('click', advanceScene);
+  if (letterContinueHandler) {
+    btn.removeEventListener('click', letterContinueHandler);
+  }
+  letterContinueHandler = () => {
+    btn.style.display = 'none';
+    btn.removeEventListener('click', letterContinueHandler);
+    letterContinueHandler = null;
+    btn.addEventListener('click', advanceScene);
+    if (pendingDialogueScene) {
+      playDialogue(pendingDialogueScene);
+      pendingDialogueScene = null;
+    }
+  };
+  btn.addEventListener('click', letterContinueHandler);
 }
 


### PR DESCRIPTION
## Summary
- delay triggering scene dialogue until the player clicks **Continue** after reading a letter
- add helper to attach the Continue button handler

## Testing
- `npm test`
- `npm run check-assets`
