### PR TITLE
Fix dialogue replay after letter view

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -390,6 +390,7 @@ function draw() {
   if (
     !isDialogueActive() &&
     currentScene !== 'bench' &&
+    !pendingDialogueScene &&
     allLettersFoundForScene(currentScene) &&
     !dialoguesPlayed[currentScene]
   ) {
@@ -546,9 +547,13 @@ function goBackScene() {
           continueBtn.style.display = 'block';
         }
       });
-    } else if (sceneHasLetters(currentScene) && allLettersFoundForScene(currentScene)) {
-      playDialogue(currentScene);
-    }
+  } else if (
+    sceneHasLetters(currentScene) &&
+    allLettersFoundForScene(currentScene) &&
+    !pendingDialogueScene
+  ) {
+    playDialogue(currentScene);
+  }
   }
 }
 


### PR DESCRIPTION
## Summary
- guard against replaying a scene's dialogue while a letter dialogue is pending
- apply the same guard in `goBackScene`

## Testing
- `npm test`
- `npm run check-assets`
