### PR TITLE
Fix bench continue flow

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -174,7 +174,7 @@ function playDialogue(scene, callback) {
       dialogueActive = false;
       dialoguesPlayed[scene] = true;
       if (continueBtn) {
-        if (scene === 'barnInside' || scene === 'pond2' || scene === 'farmMap' || scene === 'greenhouseInside' || scene === 'barn') {
+        if (scene === 'barnInside' || scene === 'pond2' || scene === 'farmMap' || scene === 'greenhouseInside' || scene === 'barn' || scene === 'bench') {
           continueBtn.style.display = 'none';
         } else {
           continueBtn.style.display = 'block';

--- a/js/letters.js
+++ b/js/letters.js
@@ -256,6 +256,10 @@ function handleLetterClicks(mx, my) {
             const btn = document.getElementById('continueBtn');
             if (btn) btn.style.display = 'block';
           }
+          if (l.letter === 'Q' && l.scene === 'bench') {
+            const btn = document.getElementById('continueBtn');
+            if (btn) btn.style.display = 'block';
+          }
         }
         if (l.letter === 'G') {
           letterGFound = true;
@@ -303,6 +307,10 @@ function checkDuckLetterCollision(duck) {
         l.y = l.bottomY;
         lettersFoundCount++;
         if (l.letter === 'D' && l.scene === 'pond2') {
+          const btn = document.getElementById('continueBtn');
+          if (btn) btn.style.display = 'block';
+        }
+        if (l.letter === 'Q' && l.scene === 'bench') {
           const btn = document.getElementById('continueBtn');
           if (btn) btn.style.display = 'block';
         }


### PR DESCRIPTION
## Summary
- hide Continue button when bench dialogue finishes
- show Continue after clicking the Q letter on the bench

## Testing
- `npm test`
- `npm run check-assets`
