### PR TITLE
Implement duck animations for cave and pond scenes

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -57,7 +57,7 @@ const dialogues = {
     { speaker: 'rabbit', text: 'I think those vegetables are around here somewhere...' }
   ],
   cave: [
-    { speaker: 'duck', text: 'Found them!' },
+    { speaker: 'duck', text: 'Found them!', pose: 'backwards' },
     { speaker: 'rabbit', text: "Silly Duck, you've mistaken shadows for reality!" },
     { speaker: 'duck', text: 'Oh, reality is so much brighter and better!' }
   ],
@@ -131,6 +131,7 @@ const dialogues = {
 
 let dialogueActive = false;
 const dialoguesPlayed = {};
+let duckFacingBackwards = false;
 
 function setCharacterState(name, speaking, pose) {
   const ch = window[name];
@@ -140,7 +141,9 @@ function setCharacterState(name, speaking, pose) {
     ch.setState(pose || 'default');
   } else {
     // When done speaking, return to the neutral mouth-closed pose
-    if (ch.states.includes('mouth-closed')) {
+    if (name === 'duck' && duckFacingBackwards) {
+      ch.setState('backwards');
+    } else if (ch.states.includes('mouth-closed')) {
       ch.setState('mouth-closed');
     } else if (ch.states.includes('closed')) {
       ch.setState('closed');
@@ -162,11 +165,21 @@ function playDialogue(scene, callback) {
   const box = document.getElementById('dialogueBox');
   const continueBtn = document.getElementById('continueBtn');
   if (continueBtn) continueBtn.style.display = 'none';
+  if (scene === 'cave') {
+    duckFacingBackwards = true;
+    const d = window.duck;
+    if (d && typeof d.setState === 'function') {
+      d.setState('backwards');
+    }
+  }
   dialogueActive = true;
   box.style.display = 'block';
   let index = 0;
   let prevSpeaker = null;
   function next() {
+    if (scene === 'cave' && index === 2) {
+      duckFacingBackwards = false;
+    }
     if (prevSpeaker) setCharacterState(prevSpeaker, false);
     if (index >= lines.length) {
       box.style.display = 'none';
@@ -196,4 +209,5 @@ if (typeof window !== 'undefined') {
   window.playDialogue = playDialogue;
   window.dialoguesPlayed = dialoguesPlayed;
   window.isDialogueActive = () => dialogueActive;
+  window.duckFacingBackwards = () => duckFacingBackwards;
 }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -40,7 +40,12 @@ function preload() {
     'right',
     'left-eyes-closed',
     'slight-left',
-    'mouth-closed'
+    'mouth-closed',
+    'backwards',
+    'swim-up',
+    'swim-down',
+    'swim-right',
+    'swim-left'
   ]);
   rabbit = new Character('rabbit', ['right-talking', 'mouth-closed']);
   // Donkey has a default image plus open and closed mouth states
@@ -350,6 +355,10 @@ function draw() {
         if (moveRight) duck.baseX += duckMoveSpeed;
         if (moveUp)    duck.baseY -= duckMoveSpeed;
         if (moveDown)  duck.baseY += duckMoveSpeed;
+        if (moveLeft)      duck.setState('swim-left');
+        else if (moveRight) duck.setState('swim-right');
+        else if (moveUp)    duck.setState('swim-up');
+        else if (moveDown)  duck.setState('swim-down');
       } else if (duckTargetX !== null && duckTargetY !== null) {
         const dx = duckTargetX - duck.baseX;
         const dy = duckTargetY - duck.baseY;
@@ -363,8 +372,15 @@ function draw() {
           duckTargetX = null;
           duckTargetY = null;
         }
+        duck.setState('mouth-closed');
+      } else {
+        duck.setState('mouth-closed');
       }
     }
+  }
+  if (currentScene !== 'pond2' &&
+      ['swim-left','swim-right','swim-up','swim-down'].includes(duck.state)) {
+    duck.setState('mouth-closed');
   }
   if (sceneHistory[sceneHistory.length - 1] !== currentScene) {
     sceneHistory.push(currentScene);


### PR DESCRIPTION
## Summary
- add `backwards` and swimming images to duck's state list
- track when duck is facing backwards in the cave dialogue
- maintain backwards pose until rabbit corrects him
- update pond2 to animate swimming based on arrow keys

## Testing
- `npm test`