### PR TITLE
Remove unused garden scene

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -3,7 +3,7 @@
 const defaultScenes = [
   'farmMap','picnic','tunnel','pond','cave','greenhouse','swing','swing2',
   'barn','barnInside','bench','dogHouse','donkey','field','flowers','flowers2',
-  'garden','vegetables','vegetables2','grass','greenhouseInside','loft','loftEntrance','mirror','pond2',
+  'vegetables','vegetables2','grass','greenhouseInside','loft','loftEntrance','mirror','pond2',
   'radioRoom','studio','start'
 ];
 

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -13,7 +13,6 @@ function preloadScenes() {
   scenes.field = loadImage('assets/images/scenes/field.png');
   scenes.flowers = loadImage('assets/images/scenes/flowers.png');
   scenes.flowers2 = loadImage('assets/images/scenes/flowers2.png');
-  scenes.garden = loadImage('assets/images/scenes/vegetables.png');
   scenes.vegetables2 = loadImage('assets/images/scenes/vegetables2.png');
   scenes.grass = loadImage('assets/images/scenes/grass.png');
   scenes.greenhouseInside = loadImage('assets/images/scenes/greenhouseInside.png');


### PR DESCRIPTION
## Summary
- stop preloading the unused `garden` scene
- remove `garden` from the default scene list

## Testing
- `npm run check-assets`
- `npm test`