### PR TITLE
Fix bench scene continue button

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -187,7 +187,16 @@ function playDialogue(scene, callback) {
       dialogueActive = false;
       dialoguesPlayed[scene] = true;
       if (continueBtn) {
-        if (scene === 'barnInside' || scene === 'pond2' || scene === 'farmMap' || scene === 'greenhouseInside' || scene === 'barn' || scene === 'bench') {
+        if (
+          scene === 'barnInside' ||
+          scene === 'pond2' ||
+          scene === 'farmMap' ||
+          scene === 'greenhouseInside' ||
+          scene === 'barn' ||
+          scene === 'bench' ||
+          scene === 'benchIntro' ||
+          scene === 'benchRest'
+        ) {
           continueBtn.style.display = 'none';
         } else {
           continueBtn.style.display = 'block';


### PR DESCRIPTION
## Summary
- stop showing continue button after bench dialogue ends

## Testing
- `npm test`
- `npm run check-assets`
