### PR TITLE
Keep duck swimming in pond2

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -136,6 +136,10 @@ let duckFacingBackwards = false;
 function setCharacterState(name, speaking, pose) {
   const ch = window[name];
   if (!ch || typeof ch.setState !== 'function') return;
+  if (name === 'duck' && typeof currentScene !== 'undefined' && currentScene === 'pond2') {
+    ch.setState('swim-down');
+    return;
+  }
   if (speaking) {
     // Use the default talking image unless a specific pose is provided
     ch.setState(pose || 'default');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -333,6 +333,7 @@ function draw() {
       moveLeft = moveRight = moveUp = moveDown = false;
       duckTargetX = null;
       duckTargetY = null;
+      duck.setState('swim-down');
     } else {
       if (moveLeft || moveRight || moveUp || moveDown) {
         duckTargetX = null;
@@ -358,9 +359,9 @@ function draw() {
           duckTargetX = null;
           duckTargetY = null;
         }
-        duck.setState('mouth-closed');
+        duck.setState('swim-down');
       } else {
-        duck.setState('mouth-closed');
+        duck.setState('swim-down');
       }
     }
   }


### PR DESCRIPTION
## Summary
- keep duck in swimming pose throughout the pond2 scene
- enforce swim-down pose during pond2 dialogue

## Testing
- `npm run check-assets`