### PR TITLE
Restrict tray selection to one choice per greenhouse visit

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -101,40 +101,44 @@ function handleSceneClicks(mx, my) {
     }
   }
   if (currentScene === 'greenhouseInside') {
-    const withinTrayA =
-      mx >= trayA.x && mx <= trayA.x + trayA.size &&
-      my >= trayA.y && my <= trayA.y + trayA.size;
-    const withinTrayB =
-      mx >= trayB.x && mx <= trayB.x + trayB.size &&
-      my >= trayB.y && my <= trayB.y + trayB.size;
-    if (withinTrayA && trayOnTable !== 'trayA') {
-      const tX = trayA.baseX;
-      const tY = trayA.baseY;
-      trayA.baseX = trayB.baseX;
-      trayA.baseY = trayB.baseY;
-      trayB.baseX = tX;
-      trayB.baseY = tY;
-      trayOnTable = 'trayA';
-      trayA.reset();
-      trayB.reset();
-      if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayA']) {
-        playDialogue('greenhouseInside_trayA');
+    if (!trayChoiceMade) {
+      const withinTrayA =
+        mx >= trayA.x && mx <= trayA.x + trayA.size &&
+        my >= trayA.y && my <= trayA.y + trayA.size;
+      const withinTrayB =
+        mx >= trayB.x && mx <= trayB.x + trayB.size &&
+        my >= trayB.y && my <= trayB.y + trayB.size;
+      if (withinTrayA && trayOnTable !== 'trayA') {
+        const tX = trayA.baseX;
+        const tY = trayA.baseY;
+        trayA.baseX = trayB.baseX;
+        trayA.baseY = trayB.baseY;
+        trayB.baseX = tX;
+        trayB.baseY = tY;
+        trayOnTable = 'trayA';
+        trayA.reset();
+        trayB.reset();
+        if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayA']) {
+          playDialogue('greenhouseInside_trayA');
+        }
+        trayChoiceMade = true;
+        clicked = true;
+      } else if (withinTrayB && trayOnTable !== 'trayB') {
+        const tX = trayA.baseX;
+        const tY = trayA.baseY;
+        trayA.baseX = trayB.baseX;
+        trayA.baseY = trayB.baseY;
+        trayB.baseX = tX;
+        trayB.baseY = tY;
+        trayOnTable = 'trayB';
+        trayA.reset();
+        trayB.reset();
+        if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayB']) {
+          playDialogue('greenhouseInside_trayB');
+        }
+        trayChoiceMade = true;
+        clicked = true;
       }
-      clicked = true;
-    } else if (withinTrayB && trayOnTable !== 'trayB') {
-      const tX = trayA.baseX;
-      const tY = trayA.baseY;
-      trayA.baseX = trayB.baseX;
-      trayA.baseY = trayB.baseY;
-      trayB.baseX = tX;
-      trayB.baseY = tY;
-      trayOnTable = 'trayB';
-      trayA.reset();
-      trayB.reset();
-      if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayB']) {
-        playDialogue('greenhouseInside_trayB');
-      }
-      clicked = true;
     }
     if (clicked) return;
   }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -10,6 +10,7 @@ let picnicReached = false,
     mapIcon;
 let mapUnlocked = false;
 let trayOnTable = 'trayB';
+let trayChoiceMade = false;
 let dialogueBox;
 
 // Movement variables for the duck in pond2
@@ -371,6 +372,9 @@ function draw() {
   }
   if (sceneHistory[sceneHistory.length - 1] !== currentScene) {
     sceneHistory.push(currentScene);
+    if (currentScene === 'greenhouseInside') {
+      trayChoiceMade = false;
+    }
   }
   backBtn.style.display = sceneHistory.length > 1 ? 'block' : 'none';
   drawScene(currentScene); // from scenes.js


### PR DESCRIPTION
## Summary
- allow greenhouse tray selection only once per visit
- reset trayChoiceMade flag when reentering the scene

## Testing
- `npm test`
- `npm run check-assets`
