### PR TITLE
Fix map continue display and barn interaction gating

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -269,6 +269,7 @@ function handleLetterClicks(mx, my) {
         }
         if (
           currentScene !== 'bench' &&
+          currentScene !== 'farmMap' &&
           typeof playDialogue === 'function' &&
           allLettersFoundForScene(currentScene) &&
           !dialoguesPlayed[currentScene]
@@ -323,6 +324,7 @@ function checkDuckLetterCollision(duck) {
       }
       if (
         currentScene !== 'bench' &&
+        currentScene !== 'farmMap' &&
         typeof playDialogue === 'function' &&
         allLettersFoundForScene(currentScene) &&
         !dialoguesPlayed[currentScene]

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -189,7 +189,13 @@ function drawSceneCharacters(scene) {
       // Mark interactive characters for hover effects
       charObj.interactive = false;
       if (scene === 'barn' && (name === 'donkey' || name === 'bat')) {
-        charObj.interactive = true;
+        const letterV =
+          typeof letters !== 'undefined'
+            ? letters.find(l => l.scene === 'barn' && l.letter === 'V')
+            : null;
+        if (letterV && letterV.found && dialoguesPlayed?.barn) {
+          charObj.interactive = true;
+        }
       }
       if (scene === 'greenhouseInside' && (name === 'trayA' || name === 'trayB')) {
         charObj.interactive = true;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -439,25 +439,28 @@ function mousePressed() {
     duckTargetY = mouseY;
   }
   if (currentScene === 'barn') {
-    if (
-      mouseX > donkey.x &&
-      mouseX < donkey.x + donkey.size &&
-      mouseY > donkey.y &&
-      mouseY < donkey.y + donkey.size
-    ) {
-      currentScene = 'donkey';
-      sceneIndex = orderedScenes.indexOf('barn');
-      return;
-    }
-    if (
-      mouseX > bat.x &&
-      mouseX < bat.x + bat.size &&
-      mouseY > bat.y &&
-      mouseY < bat.y + bat.size
-    ) {
-      currentScene = 'barnInside';
-      sceneIndex = orderedScenes.indexOf('barnInside');
-      return;
+    const letterV = letters.find(l => l.scene === 'barn' && l.letter === 'V');
+    if (letterV && letterV.found && dialoguesPlayed['barn']) {
+      if (
+        mouseX > donkey.x &&
+        mouseX < donkey.x + donkey.size &&
+        mouseY > donkey.y &&
+        mouseY < donkey.y + donkey.size
+      ) {
+        currentScene = 'donkey';
+        sceneIndex = orderedScenes.indexOf('barn');
+        return;
+      }
+      if (
+        mouseX > bat.x &&
+        mouseX < bat.x + bat.size &&
+        mouseY > bat.y &&
+        mouseY < bat.y + bat.size
+      ) {
+        currentScene = 'barnInside';
+        sceneIndex = orderedScenes.indexOf('barnInside');
+        return;
+      }
     }
   }
   if (currentScene === 'donkey') {


### PR DESCRIPTION
## Summary
- don't show Continue for map when the P letter is found
- restrict donkey and bat interactions in the barn until V is found and the barn dialogue plays

## Testing
- `npm run check-assets`