### PR TITLE
Keep duck swimming in pond2

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -136,6 +136,18 @@ let duckFacingBackwards = false;
 function setCharacterState(name, speaking, pose) {
   const ch = window[name];
   if (!ch || typeof ch.setState !== 'function') return;
+  if (
+    name === 'duck' &&
+    typeof currentScene !== 'undefined' &&
+    currentScene === 'pond2'
+  ) {
+    if (!speaking) {
+      if (!ch.state.startsWith('swim-')) {
+        ch.setState('swim-down');
+      }
+    }
+    return;
+  }
   if (speaking) {
     // Use the default talking image unless a specific pose is provided
     ch.setState(pose || 'default');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -333,6 +333,7 @@ function draw() {
       moveLeft = moveRight = moveUp = moveDown = false;
       duckTargetX = null;
       duckTargetY = null;
+      duck.setState('swim-down');
     } else {
       if (moveLeft || moveRight || moveUp || moveDown) {
         duckTargetX = null;
@@ -358,9 +359,15 @@ function draw() {
           duckTargetX = null;
           duckTargetY = null;
         }
-        duck.setState('mouth-closed');
+        const adx = Math.abs(dx);
+        const ady = Math.abs(dy);
+        if (adx > ady) {
+          duck.setState(dx > 0 ? 'swim-right' : 'swim-left');
+        } else {
+          duck.setState(dy > 0 ? 'swim-down' : 'swim-up');
+        }
       } else {
-        duck.setState('mouth-closed');
+        duck.setState('swim-down');
       }
     }
   }


### PR DESCRIPTION
## Summary
- avoid mouth-closed pose in pond2 dialogue
- face toward click target while swimming

## Testing
- `npm run check-assets`
- `npm test`
