### PR TITLE
Keep duck oriented while swimming to a click

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -136,6 +136,18 @@ let duckFacingBackwards = false;
 function setCharacterState(name, speaking, pose) {
   const ch = window[name];
   if (!ch || typeof ch.setState !== 'function') return;
+  if (
+    name === 'duck' &&
+    typeof currentScene !== 'undefined' &&
+    currentScene === 'pond2'
+  ) {
+    if (speaking) {
+      ch.setState('swim-down');
+    } else if (!ch.state.startsWith('swim-')) {
+      ch.setState('swim-down');
+    }
+    return;
+  }
   if (speaking) {
     // Use the default talking image unless a specific pose is provided
     ch.setState(pose || 'default');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -333,6 +333,7 @@ function draw() {
       moveLeft = moveRight = moveUp = moveDown = false;
       duckTargetX = null;
       duckTargetY = null;
+      duck.setState('swim-down');
     } else {
       if (moveLeft || moveRight || moveUp || moveDown) {
         duckTargetX = null;
@@ -350,17 +351,23 @@ function draw() {
         const dy = duckTargetY - duck.baseY;
         const dist = Math.sqrt(dx * dx + dy * dy);
         if (dist > duckMoveSpeed) {
-          duck.baseX += duckMoveSpeed * dx / dist;
-          duck.baseY += duckMoveSpeed * dy / dist;
+          duck.baseX += (duckMoveSpeed * dx) / dist;
+          duck.baseY += (duckMoveSpeed * dy) / dist;
         } else {
           duck.baseX = duckTargetX;
           duck.baseY = duckTargetY;
           duckTargetX = null;
           duckTargetY = null;
         }
-        duck.setState('mouth-closed');
+        const adx = Math.abs(dx);
+        const ady = Math.abs(dy);
+        if (adx > ady) {
+          duck.setState(dx > 0 ? 'swim-right' : 'swim-left');
+        } else {
+          duck.setState(dy > 0 ? 'swim-down' : 'swim-up');
+        }
       } else {
-        duck.setState('mouth-closed');
+        duck.setState('swim-down');
       }
     }
   }


### PR DESCRIPTION
## Summary
- refine `setCharacterState` so duck stays in swim poses only in pond2
- orient duck toward click direction when moving to a target

## Testing
- `npm run check-assets`
- `npm test`
