### PR TITLE
Add scene-specific character poses and positions

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -4,6 +4,8 @@ class Character {
     this.images = {};
     // Default to the neutral mouth-closed pose when the character is created
     this.state = 'mouth-closed';
+    this.baseState = 'mouth-closed';
+    this.lastScene = null;
     this.x = x;
     this.y = y;
     this.size = size;
@@ -81,6 +83,7 @@ class Character {
     this.baseX = this.x;
     this.baseY = this.y;
     this.baseSize = this.size;
+    this.baseState = this.state;
   }
 
   // Allows new poses to be added on the fly so scenes can introduce

--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -147,9 +147,11 @@ function setCharacterState(name, speaking, pose) {
     // Use the default talking image unless a specific pose is provided
     ch.setState(pose || 'default');
   } else {
-    // When done speaking, return to the neutral mouth-closed pose
+    // When done speaking, return to the character's base pose
     if (name === 'duck' && duckFacingBackwards) {
       ch.setState('backwards');
+    } else if (ch.baseState) {
+      ch.setState(ch.baseState);
     } else if (ch.states.includes('mouth-closed')) {
       ch.setState('mouth-closed');
     } else if (ch.states.includes('closed')) {

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -8,18 +8,18 @@ const defaultScenes = [
 ];
 
 const basePositions = {
-  duck:            { x: 360, y: 420, size: 100 },
-  rabbit:          { x: 420, y: 420, size: 100 },
-  donkey:          { x: 380, y: 420, size: 100 },
-  dog:             { x: 620, y: 440, size: 100 },
-  sheep:           { x: 460, y: 420, size: 100 },
-  sheepbaby:       { x: 520, y: 440, size: 80 },
-  owl:             { x: 380, y: 420, size: 100 },
-  graytortiecat:   { x: 380, y: 420, size: 100 },
-  orangecat:       { x: 450, y: 430, size: 100 },
-  chick:           { x: 380, y: 420, size: 100 },
-  bat:             { x: 420, y: 180, size: 100 },
-  birdhouse:       { x: 380, y: 420, size: 100 },
+  duck:            { x: 360, y: 420, size: 100, state: 'mouth-closed' },
+  rabbit:          { x: 420, y: 420, size: 100, state: 'mouth-closed' },
+  donkey:          { x: 380, y: 420, size: 100, state: 'mouth-closed' },
+  dog:             { x: 620, y: 440, size: 100, state: 'mouth-closed' },
+  sheep:           { x: 460, y: 420, size: 100, state: 'mouth-closed' },
+  sheepbaby:       { x: 520, y: 440, size: 80, state: 'mouth-closed' },
+  owl:             { x: 380, y: 420, size: 100, state: 'mouth-closed' },
+  graytortiecat:   { x: 380, y: 420, size: 100, state: 'mouth-closed' },
+  orangecat:       { x: 450, y: 430, size: 100, state: 'mouth-closed' },
+  chick:           { x: 380, y: 420, size: 100, state: 'mouth-closed' },
+  bat:             { x: 420, y: 180, size: 100, state: 'mouth-closed' },
+  birdhouse:       { x: 380, y: 420, size: 100, state: 'start' },
   pig:             { x: 360, y: 420, size: 100 },
   duckRabbitSwing: { x: 360, y: 420, size: 100 },
   trayA:           { x: 500, y: 420, size: 80 },
@@ -27,8 +27,8 @@ const basePositions = {
 };
 
 const sceneCharacters = {};
-// Optional position/size overrides per scene
-// sceneCharacterSettings[scene][character] = {x, y, size}
+// Optional position/size/pose overrides per scene
+// sceneCharacterSettings[scene][character] = {x, y, size, state}
 const sceneCharacterSettings = {};
 
 function addChar(scene, name) {
@@ -94,6 +94,18 @@ sceneCharacterSettings['farmMap'] = {
   sheep:     { x: 420, y: 380, size: 100 },
   sheepbaby: { x: 500, y: 420, size: 80 },
   pig:       { x: 260, y: 460, size: 100 }
+};
+
+sceneCharacterSettings['pond2'] = {
+  duck: { state: 'swim-down' }
+};
+
+sceneCharacterSettings['cave'] = {
+  duck: { state: 'backwards' }
+};
+
+sceneCharacterSettings['dogHouse'] = {
+  dog: { state: 'sad' }
 };
 
 sceneCharacterSettings['barn'] = {

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -186,6 +186,14 @@ function drawSceneCharacters(scene) {
         if (overrides.y !== undefined) charObj.y = overrides.y;
         if (overrides.size !== undefined) charObj.size = overrides.size;
       }
+      if (charObj.lastScene !== scene) {
+        const state = overrides && overrides.state !== undefined ? overrides.state : charObj.baseState;
+        if (state && typeof charObj.setState === 'function') {
+          charObj.setState(state);
+          charObj.baseState = state;
+        }
+        charObj.lastScene = scene;
+      }
       // Mark interactive characters for hover effects
       charObj.interactive = false;
       if (scene === 'barn' && (name === 'donkey' || name === 'bat')) {


### PR DESCRIPTION
## Summary
- support base state for characters and track last scene
- restore each character's base pose when not speaking
- store default pose with base positions
- allow specifying pose overrides for certain scenes
- set pose when entering a scene in `drawSceneCharacters`

## Testing
- `npm test`
- `npm run check-assets`
