### PR TITLE
Fix pond2 duck movement after dialogue

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -139,7 +139,12 @@ let duckFacingBackwards = false;
 function setCharacterState(name, speaking, pose) {
   const ch = window[name];
   if (!ch || typeof ch.setState !== 'function') return;
-  if (name === 'duck' && typeof currentScene !== 'undefined' && currentScene === 'pond2') {
+  if (
+    name === 'duck' &&
+    typeof currentScene !== 'undefined' &&
+    currentScene === 'pond2' &&
+    dialogueActive
+  ) {
     ch.setState('swim-down');
     return;
   }


### PR DESCRIPTION
## Summary
- limit 'swim-down' override for the duck to only run while a dialogue is active

## Testing
- `npm run check-assets`
