### PR TITLE
Prevent greenhouse interaction before finding E

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -425,6 +425,13 @@ function sceneHasLetters(scene) {
   return letters.some(l => l.scene === scene);
 }
 
+function isLetterFound(letter, scene) {
+  const l = letters.find(
+    lt => lt.letter === letter && (scene ? lt.scene === scene : true)
+  );
+  return !!(l && l.found);
+}
+
 function highlightMissingLetters(scene) {
   letters.forEach(l => {
     if (l.scene === scene && !l.found) {

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -101,6 +101,12 @@ function handleSceneClicks(mx, my) {
     }
   }
   if (currentScene === 'greenhouseInside') {
+    const letterEFound =
+      typeof isLetterFound === 'function' &&
+      isLetterFound('E', 'greenhouseInside');
+    if (!letterEFound) {
+      return;
+    }
     if (!trayChoiceMade) {
       const withinTrayA =
         mx >= trayA.x && mx <= trayA.x + trayA.size &&
@@ -206,7 +212,12 @@ function drawSceneCharacters(scene) {
         }
       }
       if (scene === 'greenhouseInside' && (name === 'trayA' || name === 'trayB')) {
-        charObj.interactive = true;
+        const letterEFound =
+          typeof isLetterFound === 'function' &&
+          isLetterFound('E', 'greenhouseInside');
+        if (letterEFound) {
+          charObj.interactive = true;
+        }
       }
       charObj.display();
     }


### PR DESCRIPTION
## Summary
- add `isLetterFound` helper to check if a specific letter is collected
- disable tray interaction in `greenhouseInside` scene until the E is found
- only mark trays as interactive after the E is found

## Testing
- `npm run check-assets`
- `npm test`
