### PR TITLE
Fix rabbit pose in pond2 dialogue

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -194,8 +194,14 @@ function drawSceneCharacters(scene) {
       }
       if (charObj.lastScene !== scene) {
         const state = overrides && overrides.state !== undefined ? overrides.state : charObj.baseState;
-        if (state && typeof charObj.setState === 'function') {
-          charObj.setState(state);
+        const activeDialogue = typeof isDialogueActive === 'function' && isDialogueActive();
+        if (!activeDialogue) {
+          if (state && typeof charObj.setState === 'function') {
+            charObj.setState(state);
+            charObj.baseState = state;
+          }
+        } else if (state) {
+          // Preserve the speaking pose but update the base state for later
           charObj.baseState = state;
         }
         charObj.lastScene = scene;


### PR DESCRIPTION
## Summary
- fix dialogue characters resetting when switching scenes while dialogue is active

## Testing
- `npm test`
- `npm run check-assets`
