### PR TITLE
Fix greenhouseInside logic and adjust character positions

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -124,8 +124,8 @@ sceneCharacterSettings['grass'].birdhouse = { x: 190, y: 20, size: 400 };
 sceneCharacterSettings['flowers2'].owl = { x: 200, y: 260, size: 100 };
 sceneCharacterSettings['flowers2'].birdhouse = { x: 380, y: 480, size: 100 };
 
-sceneCharacterSettings['greenhouseInside'].duck = { x: 300, y: 360, size: 100 };
-sceneCharacterSettings['greenhouseInside'].rabbit = { x: 380, y: 380, size: 100 };
+sceneCharacterSettings['greenhouseInside'].duck = { x: 300, y: 260, size: 100 };
+sceneCharacterSettings['greenhouseInside'].rabbit = { x: 380, y: 280, size: 100 };
 
 sceneCharacterSettings['cave'] = {
   duck: { x: 360, y: 420, size: 100 },

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -116,7 +116,8 @@ function handleSceneClicks(mx, my) {
     const letterEFound =
       typeof isLetterFound === 'function' &&
       isLetterFound('E', 'greenhouseInside');
-    if (!letterEFound) {
+    const promptShown = dialoguesPlayed['greenhouseInside'];
+    if (!letterEFound || !promptShown) {
       return;
     }
     if (!trayChoiceMade) {


### PR DESCRIPTION
## Summary
- wait for the greenhouseInside dialogue before allowing tray selection
- shift Duck and Rabbit higher in the greenhouseInside scene

## Testing
- `npm run check-assets`
- `npm test`