### PR TITLE
Fix chick pose state transitions

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -165,6 +165,14 @@ function setCharacterState(name, speaking, pose) {
     ch.setState('swim-down');
     return;
   }
+  if (name === 'chick') {
+    if (speaking) {
+      ch.setState('in-egg-open');
+    } else {
+      ch.setState('default');
+    }
+    return;
+  }
   if (speaking) {
     // Use the default talking image unless a specific pose is provided
     ch.setState(pose || 'default');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -115,7 +115,7 @@ function preload() {
   orangecat.state = 'mouth-closed';
   orangecat.initBase();
 
-  chick = new Character('chick', ['eggcited', 'in-egg-closed', 'in-egg-open', 'mouth-closed'], 100, 380, 420);
+  chick = new Character('chick', ['eggcited', 'in-egg-open', 'mouth-closed'], 100, 380, 420);
   chick.images['idle'] = loadImage('assets/images/chick/default.png');
   chick.state = 'mouth-closed';
 


### PR DESCRIPTION
## Summary
- remove invalid `in-egg-closed` chick state
- have the chick show `in-egg-open` when speaking and `default` otherwise

## Testing
- `npm run check-assets`
- `npm test`
