### PR TITLE
Fix sheepbaby default state

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -13,7 +13,7 @@ const basePositions = {
   donkey:          { x: 380, y: 420, size: 100, state: 'mouth-closed' },
   dog:             { x: 620, y: 440, size: 100, state: 'mouth-closed' },
   sheep:           { x: 460, y: 420, size: 100, state: 'mouth-closed' },
-  sheepbaby:       { x: 520, y: 440, size: 80, state: 'mouth-closed' },
+  sheepbaby:       { x: 520, y: 440, size: 80, state: 'slight-right' },
   owl:             { x: 380, y: 420, size: 100, state: 'mouth-closed' },
   graytortiecat:   { x: 380, y: 420, size: 100, state: 'mouth-closed' },
   orangecat:       { x: 450, y: 430, size: 100, state: 'mouth-closed' },

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -85,9 +85,9 @@ function preload() {
   sheep.state = 'mouth-closed';
   sheep.initBase();
 
-  sheepbaby = new Character('sheepbaby', ['slight-right', 'mouth-closed'], 80, 520, 440);
+  sheepbaby = new Character('sheepbaby', ['slight-right'], 80, 520, 440);
   sheepbaby.images['idle'] = loadImage('assets/images/sheepbaby/default.png');
-  sheepbaby.state = 'mouth-closed';
+  sheepbaby.state = 'slight-right';
   sheepbaby.initBase();
 
   owl = new Character('owl', [


### PR DESCRIPTION
## Summary
- remove `mouth-closed` from sheepbaby state list
- start sheepbaby in `slight-right` pose
- update base scene settings for sheepbaby

## Testing
- `npm test`
- `npm run check-assets`
