### PR TITLE
Display barn inside labels

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -43,6 +43,14 @@ function setupScenes() {
     {name: 'picnic', label: 'picnic', x: 700, y: 440, w: 50,  h: 50},
     {name: 'vegetables', label: 'vegetables', x: 715, y: 300, w: 50, h: 50}
   ];
+
+  // Interactive areas inside the barn
+  scenes.barnInsideAreas = [
+    {name: 'mirror', label: 'mirror', x: 60,  y: 350, w: 100, h: 100},
+    {name: 'radioRoom', label: 'radio room', x: 30,  y: 450, w: 100, h: 100},
+    {name: 'loftEntrance', label: 'loft entrance', x: 350, y: 350, w: 100, h: 100},
+    {name: 'studio', label: 'studio', x: 380, y: 450, w: 100, h: 100}
+  ];
 }
 
 function drawScene(scene) {
@@ -162,13 +170,7 @@ function handleSceneClicks(mx, my) {
     if (clicked) return;
   }
   if (currentScene === 'barnInside') {
-    const areas = [
-      {name: 'studio', x: 380, y: 300, w: 100, h: 100},
-      {name: 'mirror', x: 30, y: 100, w: 100, h: 100},
-      {name: 'radioRoom', x: 30, y: 300, w: 100, h: 100},
-      {name: 'loftEntrance', x: 380, y: 100, w: 100, h: 100}
-    ];
-    areas.forEach(area => {
+    scenes.barnInsideAreas.forEach(area => {
       const within =
         mx >= area.x && mx <= area.x + area.w &&
         my >= area.y && my <= area.y + area.h;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -541,6 +541,17 @@ function draw() {
       text(label, lx, ly);
     });
   }
+  if (currentScene === 'barnInside') {
+    textAlign(CENTER, CENTER);
+    fill(0);
+    textSize(16);
+    scenes.barnInsideAreas.forEach(area => {
+      const lx = area.labelX !== undefined ? area.labelX : area.x + area.w / 2;
+      const ly = area.labelY !== undefined ? area.labelY : area.y + area.h / 2;
+      const label = area.label || area.name;
+      text(label, lx, ly);
+    });
+  }
   if (currentScene === 'donkey') {
     image(barnIcon, 10, 10, 50, 50);
   }


### PR DESCRIPTION
## Summary
- expose barn inside clickable areas in `scenes`
- reuse area data for clicks
- render barn inside labels like the farm map

## Testing
- `npm run check-assets`