### PR TITLE
Implement duck-rabbit advice popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <script src="js/letters.js"></script>
   <script src="js/dialogue.js"></script>
   <div id="letterInfoBox" aria-live="polite"></div>
+  <div id="adviceBox" aria-live="polite"></div>
   <div id="dialogueBox" aria-live="polite"></div>
   <button id="continueBtn" aria-label="Continue">Continue</button>
   <button id="backBtn" aria-label="Back">Back</button>

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -6,6 +6,8 @@ var duck, rabbit, donkey, dog, sheep, sheepbaby, owl, graytortiecat, orangecat, 
 let letterGFound = false;
 let letterHFound = false;
 let duckRabbitIcon, barnIcon;
+let duckRabbitIcons = [];
+let duckRabbitIconIndex = 0;
 let picnicReached = false,
     mapIcon;
 let mapUnlocked = false;
@@ -392,7 +394,13 @@ function preload() {
   };
   trayB.initBase();
 
-  duckRabbitIcon = loadImage('assets/images/icons/duck-rabbit.png');
+  duckRabbitIcons = [
+    loadImage('assets/images/icons/duck-rabbit.png'),
+    loadImage('assets/images/icons/duck-rabbit1.png'),
+    loadImage('assets/images/icons/duck-rabbit2.png')
+  ];
+  duckRabbitIconIndex = 0;
+  duckRabbitIcon = duckRabbitIcons[duckRabbitIconIndex];
   barnIcon = loadImage('assets/images/icons/barndefault.png');
   mapIcon = loadImage('assets/images/icons/map.png');
 
@@ -627,12 +635,30 @@ function mousePressed() {
 }
 
 function showAdvice() {
+  if (typeof playSound === 'function') playSound('continue');
+  toggleDuckRabbitIcon();
+  const box = document.getElementById('adviceBox');
+  if (!box) return;
+  let msg;
   if (lettersFoundCount >= 26) {
-    alert("Duck-Rabbit says: Great job finding all the letters!");
+    msg = 'Duck-Rabbit says: Great job finding all the letters!';
   } else {
-    alert("Duck-Rabbit says: Think about things from a different perspective!");
+    msg = 'Duck-Rabbit says: Think about things from a different perspective!';
   }
+  box.textContent = msg;
+  box.style.display = 'block';
+  if (typeof box.focus === 'function') box.focus();
+  box.onclick = () => {
+    box.style.display = 'none';
+    box.onclick = null;
+  };
   highlightMissingLetters(currentScene);
+}
+
+function toggleDuckRabbitIcon() {
+  if (!Array.isArray(duckRabbitIcons) || duckRabbitIcons.length === 0) return;
+  duckRabbitIconIndex = (duckRabbitIconIndex + 1) % duckRabbitIcons.length;
+  duckRabbitIcon = duckRabbitIcons[duckRabbitIconIndex];
 }
 
 function updateBenchRestDialogue() {

--- a/style.css
+++ b/style.css
@@ -99,3 +99,20 @@ canvas {
 #letterInfoBox strong {
   font-size: 22px;
 }
+
+/* Popup for duck-rabbit advice */
+#adviceBox {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 12px 16px;
+  border: 4px solid #ffcc00;
+  border-radius: 10px;
+  font-size: 18px;
+  color: #333;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  display: none;
+  z-index: 12;
+  max-width: 60%;
+}


### PR DESCRIPTION
## Summary
- display an advice popup DOM element
- cycle duck-rabbit icon and play the continue sound on click

## Testing
- `npm run check-assets`
- `npm test`
