### PR TITLE
Fix tray interactions and adjust positions

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -98,7 +98,7 @@ function preloadLetters() {
     concept: 'Logic',
     description: 'Using reason to solve problems.',
     question: 'When do you use logic?',
-    x: 400, y: 240
+    x: 400, y: 90
   });
   letters.push({
     scene: 'tunnel',

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -87,8 +87,8 @@ sceneCharacters['swing2'] = sceneCharacters['swing2'].filter(c => c !== 'duck' &
 // Scene-specific position overrides
 sceneCharacterSettings['farmMap'] = {
   // Duck and Rabbit sit where the greenhouse link used to be
-  duck:      { x: 300, y: 100, size: 40 },
-  rabbit:    { x: 360, y: 100, size: 40 },
+  duck:      { x: 300, y: 150, size: 40 },
+  rabbit:    { x: 360, y: 150, size: 40 },
   // Owl stays in roughly the same position
   owl:       { x: 80,  y: 250, size: 80 },
   // Dog now lives where the bench link started
@@ -130,7 +130,7 @@ sceneCharacterSettings['flowers'].birdhouse = { x: 380, y: 480, size: 100 };
 
 sceneCharacterSettings['grass'].duck = { x: 100, y: 360, size: 300 };
 sceneCharacterSettings['grass'].rabbit = { x: 480, y: 380, size: 300 };
-sceneCharacterSettings['grass'].birdhouse = { x: 190, y: 20, size: 400 };
+sceneCharacterSettings['grass'].birdhouse = { x: 190, y: -10, size: 400 };
 
 // Owl is a bit lower in the second flowers scene
 sceneCharacterSettings['flowers2'].owl = { x: 200, y: 320, size: 100 };

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -40,7 +40,7 @@ function setupScenes() {
     {name: 'bench', label: 'bench', x: 20,  y: 370, w: 70,  h: 70},
     {name: 'pond', label: 'pond', x: 450, y: 380, w: 100, h: 100},
     {name: 'greenhouse', label: 'greenhouse', x: 500, y: 175, w: 50,  h: 50},
-    {name: 'picnic', label: 'picnic', x: 700, y: 440, w: 50,  h: 50},
+    {name: 'picnic', label: 'picnic', x: 700, y: 140, w: 50,  h: 50},
     {name: 'vegetables', label: 'vegetables', x: 715, y: 300, w: 50, h: 50}
   ];
 
@@ -135,13 +135,16 @@ function handleSceneClicks(mx, my) {
       const withinTrayB =
         mx >= trayB.x && mx <= trayB.x + trayB.size &&
         my >= trayB.y && my <= trayB.y + trayB.size;
-      if (withinTrayA && trayOnTable !== 'trayA') {
+      const swapTrays = () => {
         const tX = trayA.baseX;
         const tY = trayA.baseY;
         trayA.baseX = trayB.baseX;
         trayA.baseY = trayB.baseY;
         trayB.baseX = tX;
         trayB.baseY = tY;
+      };
+      if (withinTrayA) {
+        if (trayOnTable !== 'trayA') swapTrays();
         trayOnTable = 'trayA';
         trayA.reset();
         trayB.reset();
@@ -150,13 +153,8 @@ function handleSceneClicks(mx, my) {
         }
         trayChoiceMade = true;
         clicked = true;
-      } else if (withinTrayB && trayOnTable !== 'trayB') {
-        const tX = trayA.baseX;
-        const tY = trayA.baseY;
-        trayA.baseX = trayB.baseX;
-        trayA.baseY = trayB.baseY;
-        trayB.baseX = tX;
-        trayB.baseY = tY;
+      } else if (withinTrayB) {
+        if (trayOnTable !== 'trayB') swapTrays();
         trayOnTable = 'trayB';
         trayA.reset();
         trayB.reset();


### PR DESCRIPTION
## Summary
- move L letter in `vegetables2`
- adjust birdhouse in grass
- move Duck and Rabbit on the farm map
- reposition picnic link on the farm map
- allow selecting tray B in greenhouse

## Testing
- `npm run check-assets`
