### PR TITLE
Update scene positions and poses

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -141,7 +141,7 @@ const dialogues = {
   loftEntrance: [
     { speaker: 'graytortiecat', text: 'Duck and Rabbit, can you help me? I was wondering, how different could I be and still be a cat?' },
     { speaker: 'rabbit', text: 'Interesting question! What makes us who or what we are?' },
-    { speaker: 'graytortiecat', text: 'What if I was hairless, or had extra long fur? Or wagged my tail and barked?'},
+    { speaker: 'graytortiecat', text: 'What if I was hairless, or had extra long fur? Or wagged my tail and barked?', pose: 'hairless'},
     { speaker: 'duck', text: 'If you barked, I think you would be a dog!'},
     { speaker: 'rabbit', text: "That is not true- some rodents bark! That doesn't make them dogs."},
       {speaker: 'graytortiecat', text: "Hmm, I don't know if there's an easy answer to this, but keep thinking about it and let me know if you have any ideas!"}

--- a/js/letters.js
+++ b/js/letters.js
@@ -202,7 +202,7 @@ function preloadLetters() {
     concept: 'You',
     description: 'You are the wonderful person you are!',
     question: 'What do you like about yourself, and what could you work on to be better?',
-    x: 280, y: 160
+    x: 400, y: 300
   });
   letters.push({
     scene: 'loft',

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -92,9 +92,9 @@ sceneCharacterSettings['farmMap'] = {
   // Owl stays in roughly the same position
   owl:       { x: 80,  y: 250, size: 80 },
   // Dog now lives where the bench link started
-  dog:       { x: 30,  y: 30,  size: 50 },
+  dog:       { x: 30,  y: 40,  size: 50 },
   // Sheep family appears above the owl and slightly left
-  sheep:     { x: 15,  y: 150, size: 50 },
+  sheep:     { x: 15,  y: 160, size: 50 },
   sheepbaby: { x: 75,  y: 180, size: 40 },
   // Pig touches the top edge of the map
   pig:       { x: 465, y: -5, size: 80 }
@@ -151,8 +151,8 @@ sceneCharacterSettings['dogHouse'] = {
 };
 
 sceneCharacterSettings['field'] = {
-  sheep: { y: 320 },
-  sheepbaby: { x: 520, y: 340 },
+  sheep: { y: 70 },
+  sheepbaby: { x: 520, y: 90 },
   duck: { x: 360, y: 500 }
 };
 
@@ -185,7 +185,8 @@ sceneCharacterSettings['swing'] = {
 sceneCharacterSettings['swing2'] = { pig: { x: 235, y: 220, size: 330 } };
 
 sceneCharacterSettings['radioRoom'] = {
-  chick: { y: 320 }
+  chick: { y: 320, state: 'default' },
+  duck: { y: 500 }
 };
 
 sceneCharacterSettings['loftEntrance'].graytortiecat = {

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -36,7 +36,7 @@ function setupScenes() {
   scenes.interactiveAreas = [
     {name: 'barn', label: 'barn', x: 220, y: 10,  w: 200, h: 200},
     {name: 'swing', label: 'swing', x: 460, y: 0,   w: 50,  h: 50},
-    {name: 'dogHouse', label: 'doghouse', x: 30,  y: 30,  w: 50,  h: 50},
+    {name: 'dogHouse', label: 'doghouse', x: 30,  y: 30,  w: 50,  h: 50, labelY: 65},
     {name: 'bench', label: 'bench', x: 20,  y: 370, w: 70,  h: 70},
     {name: 'pond', label: 'pond', x: 450, y: 380, w: 100, h: 100},
     {name: 'greenhouse', label: 'greenhouse', x: 500, y: 175, w: 50,  h: 50},
@@ -46,10 +46,10 @@ function setupScenes() {
 
   // Interactive areas inside the barn
   scenes.barnInsideAreas = [
-    {name: 'mirror', label: 'mirror', x: 60,  y: 350, w: 100, h: 100},
+    {name: 'mirror', label: 'mirror', x: 120,  y: 350, w: 100, h: 100},
     {name: 'radioRoom', label: 'radio room', x: 30,  y: 450, w: 100, h: 100},
-    {name: 'loftEntrance', label: 'loft entrance', x: 350, y: 350, w: 100, h: 100},
-    {name: 'studio', label: 'studio', x: 380, y: 450, w: 100, h: 100}
+    {name: 'loftEntrance', label: 'loft entrance', x: 650, y: 350, w: 100, h: 100},
+    {name: 'studio', label: 'studio', x: 680, y: 450, w: 100, h: 100}
   ];
 }
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -508,12 +508,20 @@ function draw() {
     if (!dialoguesPlayed['dogHouse']) {
       playDialogue('dogHouse', () => {
         if (sceneCharacterSettings['dogHouse'] && sceneCharacterSettings['dogHouse'].dog) {
-          sceneCharacterSettings['dogHouse'].dog.state = 'happy';
+          sceneCharacterSettings['dogHouse'].dog.state = 'default';
+        }
+        if (typeof dog !== 'undefined') {
+          dog.baseState = 'default';
+          dog.setState('default');
         }
       });
     } else if (dogHouseVisits > 1 && !dialoguesPlayed['dogHouseReturn']) {
       if (sceneCharacterSettings['dogHouse'] && sceneCharacterSettings['dogHouse'].dog) {
-        sceneCharacterSettings['dogHouse'].dog.state = 'happy';
+        sceneCharacterSettings['dogHouse'].dog.state = 'default';
+      }
+      if (typeof dog !== 'undefined') {
+        dog.baseState = 'default';
+        dog.setState('default');
       }
       playDialogue('dogHouseReturn');
     }


### PR DESCRIPTION
## Summary
- adjust farmMap character placement
- move barnInside navigation links
- reposition field sheep family
- center letter Y in mirror scene
- tweak radioRoom character positions
- keep Dog in default pose after dogHouse visit
- switch to hairless pose in loftEntrance dialogue

## Testing
- `npm run check-assets`