### PR TITLE
Add icon toggling and sounds

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -252,6 +252,10 @@ function handleLetterClicks(mx, my) {
           l.x = l.bottomX;
           l.y = l.bottomY;
           lettersFoundCount++;
+          if (typeof playSound === 'function') playSound('achieve');
+          if (lettersFoundCount === 26 && typeof playSound === 'function') {
+            playSound('win');
+          }
           if (l.letter === 'D' && l.scene === 'pond2') {
             const btn = document.getElementById('continueBtn');
             if (btn) btn.style.display = 'block';
@@ -308,6 +312,10 @@ function checkDuckLetterCollision(duck) {
         l.x = l.bottomX;
         l.y = l.bottomY;
         lettersFoundCount++;
+        if (typeof playSound === 'function') playSound('achieve');
+        if (lettersFoundCount === 26 && typeof playSound === 'function') {
+          playSound('win');
+        }
         if (l.letter === 'D' && l.scene === 'pond2') {
           const btn = document.getElementById('continueBtn');
           if (btn) btn.style.display = 'block';

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -67,6 +67,7 @@ function handleSceneClicks(mx, my) {
         my > area.y &&
         my < area.y + area.h;
       if (withinArea) {
+        if (typeof playSound === 'function') playSound('click');
         currentScene = area.name;
         if (typeof orderedScenes !== 'undefined') {
           const idx = orderedScenes.indexOf(area.name);
@@ -82,7 +83,10 @@ function handleSceneClicks(mx, my) {
       my >= char.y && my <= char.y + char.size;
 
     if (typeof dog !== 'undefined' && withinChar(dog)) {
-      if (typeof playSound === 'function') playSound('dog');
+      if (typeof playSound === 'function') {
+        playSound('click');
+        playSound('dog');
+      }
       currentScene = 'dogHouse';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('dogHouse');
@@ -94,7 +98,10 @@ function handleSceneClicks(mx, my) {
       typeof sheep !== 'undefined' && withinChar(sheep) ||
       typeof sheepbaby !== 'undefined' && withinChar(sheepbaby)
     ) {
-      if (typeof playSound === 'function') playSound('sheep');
+      if (typeof playSound === 'function') {
+        playSound('click');
+        playSound('sheep');
+      }
       currentScene = 'field';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('field');
@@ -103,7 +110,10 @@ function handleSceneClicks(mx, my) {
     }
 
     if (typeof pig !== 'undefined' && withinChar(pig)) {
-      if (typeof playSound === 'function') playSound('pig');
+      if (typeof playSound === 'function') {
+        playSound('click');
+        playSound('pig');
+      }
       currentScene = 'swing';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('swing');
@@ -112,7 +122,10 @@ function handleSceneClicks(mx, my) {
     }
 
     if (typeof owl !== 'undefined' && withinChar(owl)) {
-      if (typeof playSound === 'function') playSound('owl');
+      if (typeof playSound === 'function') {
+        playSound('click');
+        playSound('owl');
+      }
       currentScene = 'flowers';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('flowers');
@@ -144,6 +157,7 @@ function handleSceneClicks(mx, my) {
         trayB.baseY = tY;
       };
       if (withinTrayA) {
+        if (typeof playSound === 'function') playSound('click');
         if (trayOnTable !== 'trayA') swapTrays();
         trayOnTable = 'trayA';
         trayA.reset();
@@ -154,6 +168,7 @@ function handleSceneClicks(mx, my) {
         trayChoiceMade = true;
         clicked = true;
       } else if (withinTrayB) {
+        if (typeof playSound === 'function') playSound('click');
         if (trayOnTable !== 'trayB') swapTrays();
         trayOnTable = 'trayB';
         trayA.reset();
@@ -173,6 +188,7 @@ function handleSceneClicks(mx, my) {
         mx >= area.x && mx <= area.x + area.w &&
         my >= area.y && my <= area.y + area.h;
       if (within) {
+        if (typeof playSound === 'function') playSound('click');
         currentScene = area.name;
         if (area.name === 'loftEntrance') {
           sceneIndex = orderedScenes.indexOf('loftEntrance');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -5,7 +5,7 @@ let currentScene = 'start';
 var duck, rabbit, donkey, dog, sheep, sheepbaby, owl, graytortiecat, orangecat, chick, bat, birdhouse, pig, duckRabbitSwing, trayA, trayB;
 let letterGFound = false;
 let letterHFound = false;
-let duckRabbitIcon, barnIcon;
+let duckRabbitIcons = [], duckRabbitIconIndex = 0, barnIcon;
 let picnicReached = false,
     mapIcon;
 let mapUnlocked = false;
@@ -392,7 +392,11 @@ function preload() {
   };
   trayB.initBase();
 
-  duckRabbitIcon = loadImage('assets/images/icons/duck-rabbit.png');
+  duckRabbitIcons = [
+    loadImage('assets/images/icons/duck-rabbit1.png'),
+    loadImage('assets/images/icons/duck-rabbit.png'),
+    loadImage('assets/images/icons/duck-rabbit2.png')
+  ];
   barnIcon = loadImage('assets/images/icons/barndefault.png');
   mapIcon = loadImage('assets/images/icons/map.png');
 
@@ -568,13 +572,41 @@ function draw() {
     currentScene !== 'farmMap' &&
     allLettersFoundForScene(currentScene)
   ) {
-    image(mapIcon, 10, 10, 50, 50);
+    let mSize = 50;
+    let mxPos = 10;
+    let myPos = 10;
+    let dSize = mSize;
+    let dx = mxPos;
+    let dy = myPos;
+    if (
+      mouseX >= mxPos &&
+      mouseX <= mxPos + mSize &&
+      mouseY >= myPos &&
+      mouseY <= myPos + mSize
+    ) {
+      dSize *= 1.05;
+      dx -= (dSize - mSize) / 2;
+      dy -= (dSize - mSize) / 2;
+    }
+    image(mapIcon, dx, dy, dSize, dSize);
   }
-  if (currentScene === 'start') {
-    image(duckRabbitIcon, width / 2 - 100, height / 2 - 100, 200, 200);
-  } else {
-    image(duckRabbitIcon, width - 70, 10, 60, 60);
+  let drSize = currentScene === 'start' ? 200 : 60;
+  let drX = currentScene === 'start' ? width / 2 - drSize / 2 : width - 70;
+  let drY = currentScene === 'start' ? height / 2 - drSize / 2 : 10;
+  let dSize = drSize;
+  let dx = drX;
+  let dy = drY;
+  if (
+    mouseX >= drX &&
+    mouseX <= drX + drSize &&
+    mouseY >= drY &&
+    mouseY <= drY + drSize
+  ) {
+    dSize *= 1.05;
+    dx -= (dSize - drSize) / 2;
+    dy -= (dSize - drSize) / 2;
   }
+  image(duckRabbitIcons[duckRabbitIconIndex], dx, dy, dSize, dSize);
   drawLetters(currentScene); // draw letters on top
 }
 
@@ -594,7 +626,10 @@ function mousePressed() {
         mouseY > donkey.y &&
         mouseY < donkey.y + donkey.size
       ) {
-        if (typeof playSound === 'function') playSound('donkey');
+        if (typeof playSound === 'function') {
+          playSound('click');
+          playSound('donkey');
+        }
         currentScene = 'donkey';
         sceneIndex = orderedScenes.indexOf('barn');
         return;
@@ -605,7 +640,10 @@ function mousePressed() {
         mouseY > bat.y &&
         mouseY < bat.y + bat.size
       ) {
-        if (typeof playSound === 'function') playSound('bat');
+        if (typeof playSound === 'function') {
+          playSound('click');
+          playSound('bat');
+        }
         currentScene = 'barnInside';
         sceneIndex = orderedScenes.indexOf('barnInside');
         return;
@@ -614,6 +652,7 @@ function mousePressed() {
   }
   if (currentScene === 'donkey') {
     if (mouseX >= 10 && mouseX <= 60 && mouseY >= 10 && mouseY <= 60) {
+      if (typeof playSound === 'function') playSound('click');
       currentScene = 'barn';
       sceneIndex = orderedScenes.indexOf('barn');
       return;
@@ -625,11 +664,22 @@ function mousePressed() {
     allLettersFoundForScene(currentScene)
   ) {
     if (mouseX >= 10 && mouseX <= 60 && mouseY >= 10 && mouseY <= 60) {
+      if (typeof playSound === 'function') playSound('click');
       currentScene = 'farmMap';
       return;
     }
   }
-  if (mouseX > width - 70 && mouseY < 70) {
+  const drSize = currentScene === 'start' ? 200 : 60;
+  const drX = currentScene === 'start' ? width / 2 - drSize / 2 : width - 70;
+  const drY = currentScene === 'start' ? height / 2 - drSize / 2 : 10;
+  if (
+    mouseX >= drX &&
+    mouseX <= drX + drSize &&
+    mouseY >= drY &&
+    mouseY <= drY + drSize
+  ) {
+    if (typeof playSound === 'function') playSound('click');
+    duckRabbitIconIndex = (duckRabbitIconIndex + 1) % duckRabbitIcons.length;
     showAdvice();
   }
 }

--- a/js/sounds.js
+++ b/js/sounds.js
@@ -12,6 +12,9 @@ function preloadSounds() {
   sounds.graytortiecat = loadSound('assets/audio/cat1.wav');
   sounds.orangecat = loadSound('assets/audio/cat2.wav');
   sounds.back = loadSound('assets/audio/back.wav');
+  sounds.achieve = loadSound('assets/audio/achieve.wav');
+  sounds.win = loadSound('assets/audio/win.wav');
+  sounds.click = loadSound('assets/audio/click.wav');
 }
 function playSound(name) {
   let s;


### PR DESCRIPTION
## Summary
- add audio effects for achievements, winning, and clicking
- let the duck-rabbit icon cycle through three images
- play sound when interactive areas are clicked
- enlarge map and duck-rabbit icons on hover
- play achievement and win sounds when letters are found

## Testing
- `npm run check-assets`