### PR TITLE
Sync greenhouse tray coordinates

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -155,6 +155,10 @@ function handleSceneClicks(mx, my) {
         trayA.baseY = trayB.baseY;
         trayB.baseX = tX;
         trayB.baseY = tY;
+        sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX;
+        sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY;
+        sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX;
+        sceneCharacterSettings['greenhouseInside'].trayB.y = trayB.baseY;
       };
       if (withinTrayA) {
         if (typeof playSound === 'function') playSound('click');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -485,6 +485,10 @@ function draw() {
         trayA.baseY = 420;
         trayB.baseX = 360;
         trayB.baseY = 420;
+        sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX;
+        sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY;
+        sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX;
+        sceneCharacterSettings['greenhouseInside'].trayB.y = trayB.baseY;
         trayA.reset();
         trayB.reset();
       }


### PR DESCRIPTION
## Summary
- keep trays' coordinates synced with scene settings when swapping
- reset tray base positions and scene settings when entering greenhouse

## Testing
- `npm run check-assets`