### PR TITLE
Adjust layout & pond link

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -122,7 +122,7 @@ function preloadLetters() {
     concept: 'Observation',
     description: 'Watching carefully to learn.',
     question: 'What have you discovered by observing?',
-    x: 550, y: 380
+    x: 560, y: 395
   });
   letters.push({
     scene: 'farmMap',
@@ -230,7 +230,7 @@ function initLetterBottomPositions() {
   letters.forEach(l => {
     const idx = l.letter.charCodeAt(0) - 65;
     if (idx >= 0 && idx < 26) {
-      const spacing = width / 26;
+      const spacing = (width - 60) / 26;
       l.bottomX = spacing * (idx + 0.5);
       l.bottomY = height - l.size / 2 - 10;
     }

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -90,7 +90,7 @@ sceneCharacterSettings['farmMap'] = {
   duck:      { x: 300, y: 150, size: 40 },
   rabbit:    { x: 360, y: 150, size: 40 },
   // Owl stays in roughly the same position
-  owl:       { x: 80,  y: 250, size: 80 },
+  owl:       { x: 40,  y: 250, size: 80 },
   // Dog now lives where the bench link started
   dog:       { x: 30,  y: 40,  size: 50 },
   // Sheep family appears above the owl and slightly left
@@ -190,7 +190,7 @@ sceneCharacterSettings['swing'] = {
 sceneCharacterSettings['swing2'] = { pig: { x: 235, y: 220, size: 330 } };
 
 sceneCharacterSettings['radioRoom'] = {
-  chick: { x: 350, y: 320, state: 'default' },
+  chick: { x: 325, y: 320, state: 'default' },
   duck: { y: 500 }
 };
 

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -36,7 +36,7 @@ function setupScenes() {
   scenes.interactiveAreas = [
     {name: 'barn', label: 'barn', x: 220, y: 10,  w: 200, h: 200},
     {name: 'swing', label: 'swing', x: 460, y: 0,   w: 50,  h: 50},
-    {name: 'dogHouse', label: 'doghouse', x: 30,  y: 30,  w: 50,  h: 50, labelY: 65},
+    {name: 'dogHouse', label: 'doghouse', x: 30,  y: 30,  w: 50,  h: 50, labelY: 75},
     {name: 'bench', label: 'bench', x: 20,  y: 370, w: 70,  h: 70},
     {name: 'pond', label: 'pond', x: 450, y: 380, w: 100, h: 100},
     {name: 'greenhouse', label: 'greenhouse', x: 500, y: 175, w: 50,  h: 50},
@@ -48,8 +48,8 @@ function setupScenes() {
   scenes.barnInsideAreas = [
     {name: 'mirror', label: 'mirror', x: 120,  y: 350, w: 100, h: 100},
     {name: 'radioRoom', label: 'radio room', x: 30,  y: 450, w: 100, h: 100},
-    {name: 'loftEntrance', label: 'loft entrance', x: 640, y: 350, w: 100, h: 100},
-    {name: 'studio', label: 'studio', x: 690, y: 450, w: 100, h: 100}
+    {name: 'loftEntrance', label: 'loft entrance', x: 640, y: 350, w: 100, h: 100, labelX: 680},
+    {name: 'studio', label: 'studio', x: 690, y: 450, w: 100, h: 100, labelX: 745}
   ];
 }
 
@@ -68,9 +68,10 @@ function handleSceneClicks(mx, my) {
         my < area.y + area.h;
       if (withinArea) {
         if (typeof playSound === 'function') playSound('click');
-        currentScene = area.name;
+        const dest = area.name === 'pond' ? 'pond2' : area.name;
+        currentScene = dest;
         if (typeof orderedScenes !== 'undefined') {
-          const idx = orderedScenes.indexOf(area.name);
+          const idx = orderedScenes.indexOf(dest);
           if (idx !== -1) sceneIndex = idx;
         }
         clicked = true;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -104,10 +104,10 @@ function updateCursor() {
   if (
     !usePointer &&
     lettersFoundCount > 0 &&
-    mouseX >= width - 130 &&
-    mouseX <= width - 80 &&
-    mouseY >= 10 &&
-    mouseY <= 60
+    mouseX >= width - 60 &&
+    mouseX <= width - 10 &&
+    mouseY >= height - 60 &&
+    mouseY <= height - 10
   ) {
     usePointer = true;
   }
@@ -608,8 +608,8 @@ function draw() {
   }
   if (lettersFoundCount > 0) {
     let aSize = 50;
-    let ax = width - 130;
-    let ay = 10;
+    let ax = width - 60;
+    let ay = height - 60;
     let adSize = aSize;
     let adx = ax;
     let ady = ay;
@@ -721,8 +721,8 @@ function mousePressed() {
   }
   if (lettersFoundCount > 0) {
     const aSize = 50;
-    const ax = width - 130;
-    const ay = 10;
+    const ax = width - 60;
+    const ay = height - 60;
     if (
       mouseX >= ax &&
       mouseX <= ax + aSize &&


### PR DESCRIPTION
## Summary
- adjust `doghouse` label position and barn scene text links
- reroute pond link to `pond2`
- tweak owl and chick placements
- nudge letter O in radio room
- reserve space for answers icon at bottom

## Testing
- `npm run check-assets`