### PR TITLE
Prevent barn navigation during dialogue

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -188,6 +188,7 @@ function handleSceneClicks(mx, my) {
     if (clicked) return;
   }
   if (currentScene === 'barnInside') {
+    if (typeof isDialogueActive === 'function' && isDialogueActive()) return;
     scenes.barnInsideAreas.forEach(area => {
       const within =
         mx >= area.x && mx <= area.x + area.w &&


### PR DESCRIPTION
## Summary
- block barn inside area clicks while dialogue is active

## Testing
- `npm test`
- `npm run check-assets`
