### PR TITLE
Handle dialogues on scene switches

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -154,6 +154,7 @@ const dialogues = {
 
 let dialogueActive = false;
 const dialoguesPlayed = {};
+let currentSpeaker = null;
 let duckFacingBackwards = false;
 
 function setCharacterState(name, speaking, pose) {
@@ -218,6 +219,7 @@ function playDialogue(scene, callback) {
   box.style.display = 'block';
   let index = 0;
   let prevSpeaker = null;
+  currentSpeaker = null;
   function next() {
     if (scene === 'cave' && index === 2) {
       duckFacingBackwards = false;
@@ -249,6 +251,7 @@ function playDialogue(scene, callback) {
     }
     const line = lines[index++];
     prevSpeaker = line.speaker;
+    currentSpeaker = line.speaker;
     box.textContent = line.text;
     setCharacterState(line.speaker, true, line.pose);
   }
@@ -256,9 +259,24 @@ function playDialogue(scene, callback) {
   next();
 }
 
+function stopDialogue() {
+  const box = document.getElementById('dialogueBox');
+  if (box) {
+    box.style.display = 'none';
+    box.onclick = null;
+  }
+  if (currentSpeaker) {
+    setCharacterState(currentSpeaker, false);
+    currentSpeaker = null;
+  }
+  duckFacingBackwards = false;
+  dialogueActive = false;
+}
+
 if (typeof window !== 'undefined') {
   window.playDialogue = playDialogue;
   window.dialoguesPlayed = dialoguesPlayed;
   window.isDialogueActive = () => dialogueActive;
   window.duckFacingBackwards = () => duckFacingBackwards;
+  window.stopDialogue = stopDialogue;
 }

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -88,6 +88,7 @@ function handleSceneClicks(mx, my) {
       if (withinArea) {
         if (typeof playSound === 'function') playSound('click');
         const dest = area.name === 'pond' ? 'pond2' : area.name;
+        if (typeof stopDialogue === 'function') stopDialogue();
         currentScene = dest;
         if (typeof orderedScenes !== 'undefined') {
           const idx = orderedScenes.indexOf(dest);
@@ -107,6 +108,7 @@ function handleSceneClicks(mx, my) {
         playSound('click');
         playSound('dog');
       }
+      if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'dogHouse';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('dogHouse');
@@ -122,6 +124,7 @@ function handleSceneClicks(mx, my) {
         playSound('click');
         playSound('sheep');
       }
+      if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'field';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('field');
@@ -134,6 +137,7 @@ function handleSceneClicks(mx, my) {
         playSound('click');
         playSound('pig');
       }
+      if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'swing';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('swing');
@@ -146,6 +150,7 @@ function handleSceneClicks(mx, my) {
         playSound('click');
         playSound('owl');
       }
+      if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'flowers';
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('flowers');
@@ -214,6 +219,7 @@ function handleSceneClicks(mx, my) {
         my >= area.y && my <= area.y + area.h;
       if (within) {
         if (typeof playSound === 'function') playSound('click');
+        if (typeof stopDialogue === 'function') stopDialogue();
         currentScene = area.name;
         if (area.name === 'loftEntrance') {
           sceneIndex = orderedScenes.indexOf('loftEntrance');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -546,6 +546,9 @@ function draw() {
       playDialogue('dogHouseReturn');
     }
   }
+  if (!isDialogueActive() && currentScene === 'swing') {
+    playDialogue('swing');
+  }
   if (
     !isDialogueActive() &&
     currentScene !== 'bench' &&
@@ -680,6 +683,7 @@ function mousePressed() {
           playSound('click');
           playSound('donkey');
         }
+        if (typeof stopDialogue === 'function') stopDialogue();
         currentScene = 'donkey';
         sceneIndex = orderedScenes.indexOf('barn');
         return;
@@ -694,6 +698,7 @@ function mousePressed() {
           playSound('click');
           playSound('bat');
         }
+        if (typeof stopDialogue === 'function') stopDialogue();
         currentScene = 'barnInside';
         sceneIndex = orderedScenes.indexOf('barnInside');
         return;
@@ -703,6 +708,7 @@ function mousePressed() {
   if (currentScene === 'donkey') {
     if (mouseX >= 10 && mouseX <= 60 && mouseY >= 10 && mouseY <= 60) {
       if (typeof playSound === 'function') playSound('click');
+      if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'barn';
       sceneIndex = orderedScenes.indexOf('barn');
       return;
@@ -715,6 +721,7 @@ function mousePressed() {
   ) {
     if (mouseX >= 10 && mouseX <= 60 && mouseY >= 10 && mouseY <= 60) {
       if (typeof playSound === 'function') playSound('click');
+      if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'farmMap';
       return;
     }
@@ -809,6 +816,7 @@ function advanceScene() {
   if (typeof playSound === 'function') playSound('continue');
   if (currentScene === 'donkey') {
     if (typeof playSound === 'function') playSound('transition');
+    if (typeof stopDialogue === 'function') stopDialogue();
     currentScene = 'barn';
     sceneIndex = orderedScenes.indexOf('barn');
     continueBtn.style.display = 'none';
@@ -816,6 +824,7 @@ function advanceScene() {
   }
   if (['studio','mirror','radioRoom'].includes(currentScene)) {
     if (typeof playSound === 'function') playSound('transition');
+    if (typeof stopDialogue === 'function') stopDialogue();
     currentScene = 'barnInside';
     sceneIndex = orderedScenes.indexOf('barnInside');
     continueBtn.style.display = 'none';
@@ -831,6 +840,7 @@ function advanceScene() {
     return;
   }
   if (typeof playSound === 'function') playSound('transition');
+  if (typeof stopDialogue === 'function') stopDialogue();
   currentScene = orderedScenes[sceneIndex];
   // Hide the button immediately after switching scenes; it will be
   // displayed again when the next dialogue finishes.
@@ -841,6 +851,7 @@ function goBackScene() {
   if (sceneHistory.length > 1) {
     sceneHistory.pop();
     if (typeof playSound === 'function') playSound('back');
+    if (typeof stopDialogue === 'function') stopDialogue();
     currentScene = sceneHistory[sceneHistory.length - 1];
     const idx = orderedScenes.indexOf(currentScene);
     if (idx !== -1) sceneIndex = idx;


### PR DESCRIPTION
## Summary
- add a `stopDialogue` helper to end dialogues immediately
- stop running dialogue when navigating to a new scene
- always play swing dialogue when entering the swing scene

## Testing
- `npm test`
- `npm run check-assets`
