### PR TITLE
Improve loft meditation interactions

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -146,8 +146,18 @@ const dialogues = {
       {speaker: 'graytortiecat', text: "Hmm, I don't know if there's an easy answer to this, but keep thinking about it and let me know if you have any ideas!"}
   ],
   loft: [
-    { speaker: 'owl', text: "Let's meditate together. Close your eyes."},
-    { speaker: 'owl', text: "Sit on the floor. Breathe deeply, calm your mind, and relax." }
+    {
+      speaker: 'owl',
+      text: "Let's meditate together. Close your eyes.",
+      pose: 'meditating-mouth-open',
+      actions: { duck: 'eyes-closed', rabbit: 'eyes-closed' }
+    },
+    {
+      speaker: 'owl',
+      text: "Sit on the floor. Breathe deeply, calm your mind, and relax.",
+      pose: 'meditating-mouth-open',
+      actions: { duck: 'meditating', rabbit: 'meditating' }
+    }
   ]
 };
 
@@ -253,6 +263,14 @@ function playDialogue(scene, callback) {
     currentSpeaker = line.speaker;
     box.textContent = line.text;
     setCharacterState(line.speaker, true, line.pose);
+    if (line.actions) {
+      Object.entries(line.actions).forEach(([name, state]) => {
+        const ch = window[name];
+        if (ch && typeof ch.setState === 'function') {
+          ch.setState(state);
+        }
+      });
+    }
   }
   box.onclick = next;
   next();

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -199,7 +199,8 @@ sceneCharacterSettings['loftEntrance'].graytortiecat = {
 };
 
 sceneCharacterSettings['loft'].owl = {
-  x: 200
+  x: 200,
+  state: 'meditating'
 };
 
 if (typeof window !== 'undefined') {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -135,6 +135,8 @@ function preload() {
     'left',
     'right',
     'left-eyes-closed',
+    'eyes-closed',
+    'meditating',
     'slight-left',
     'mouth-closed',
     'backwards',
@@ -143,7 +145,11 @@ function preload() {
     'swim-right',
     'swim-left'
   ], 100, 360, 420);
-  rabbit = new Character('rabbit', ['mouth-closed'], 100, 420, 420);
+  rabbit = new Character('rabbit', [
+    'mouth-closed',
+    'eyes-closed',
+    'meditating'
+  ], 100, 420, 420);
   // Donkey has a default image plus open and closed mouth states
   donkey = new Character('donkey', ['open', 'closed', 'mouth-closed'], 100, 380, 420);
   donkey.images['idle'] = loadImage('assets/images/donkey/default.png');
@@ -175,7 +181,9 @@ function preload() {
   owl = new Character('owl', [
     'eyes-closed-mouth-open',
     'eyes-closed',
-    'mouth-closed'
+    'mouth-closed',
+    'meditating',
+    'meditating-mouth-open'
   ], 100, 380, 420);
 
   graytortiecat = new Character('graytortiecat', ['fluffy', 'hairless', 'mouth-closed'], 100, 380, 420);
@@ -489,6 +497,9 @@ function draw() {
     if (currentScene === 'dogHouse') {
       dogHouseVisits++;
     }
+    if (currentScene === 'loft') {
+      dialoguesPlayed['loft'] = false;
+    }
     if (currentScene === 'greenhouseInside') {
       trayChoiceMade = false;
       trayOnTable = 'trayB';
@@ -545,6 +556,9 @@ function draw() {
       }
       playDialogue('dogHouseReturn');
     }
+  }
+  if (!isDialogueActive() && currentScene === 'loft' && !dialoguesPlayed['loft']) {
+    playDialogue('loft');
   }
   if (!isDialogueActive() && currentScene === 'swing') {
     playDialogue('swing');


### PR DESCRIPTION
## Summary
- make owl meditate by default in the loft
- add meditating poses to owl, duck, and rabbit
- change loft dialogue so owl guides meditation
- apply duck/rabbit pose changes during dialogue
- replay loft dialogue on every visit

## Testing
- `npm run check-assets`