### PR TITLE
Fix continue button after letters

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -361,6 +361,16 @@ function closeLetterInfo() {
   if (pendingDialogueScene) {
     playDialogue(pendingDialogueScene);
     pendingDialogueScene = null;
+  } else {
+    const btn = document.getElementById('continueBtn');
+    if (
+      btn &&
+      currentScene !== 'farmMap' &&
+      dialoguesPlayed[currentScene] &&
+      allLettersFoundForScene(currentScene)
+    ) {
+      btn.style.display = 'block';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- show the continue button when all letters are found after a scene's dialogue

## Testing
- `npm test`
- `npm run check-assets`
