### PR TITLE
Ensure continue button returns after letter prompts

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -239,6 +239,9 @@ function playDialogue(scene, callback) {
       box.onclick = null;
       dialogueActive = false;
       dialoguesPlayed[scene] = true;
+      if (scene === 'benchIntro' || scene === 'benchRest') {
+        dialoguesPlayed['bench'] = true;
+      }
       if (continueBtn) {
         if (
           scene === 'barnInside' ||

--- a/js/letters.js
+++ b/js/letters.js
@@ -363,10 +363,14 @@ function closeLetterInfo() {
     pendingDialogueScene = null;
   } else {
     const btn = document.getElementById('continueBtn');
+    const benchReady =
+      currentScene === 'bench' &&
+      (dialoguesPlayed.benchIntro || dialoguesPlayed.benchRest);
+    const pond2Ready = currentScene === 'pond2' && dialoguesPlayed.pond2;
     if (
       btn &&
       currentScene !== 'farmMap' &&
-      dialoguesPlayed[currentScene] &&
+      (dialoguesPlayed[currentScene] || benchReady || pond2Ready) &&
       allLettersFoundForScene(currentScene)
     ) {
       btn.style.display = 'block';


### PR DESCRIPTION
## Summary
- mark `bench` dialogue complete when benchIntro or benchRest finish
- show continue button in bench and pond2 scenes after closing letter info

## Testing
- `npm run check-assets`