### PR TITLE
Add radio room revisit dialogue

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -140,6 +140,9 @@ const dialogues = {
     { speaker: 'chick', text: 'Not yet, but let me finish hatching and I will!', pose: 'default' },
     { speaker: 'chick', text: 'Wow, seeing color is so beautiful! I never truly understood.' }
   ],
+  radioRoomReturn: [
+    { speaker: 'chick', text: "All of the physical facts didn't prepare me for what it is like to see color!" }
+  ],
   loftEntrance: [
     { speaker: 'graytortiecat', text: 'Duck and Rabbit, can you help me? I was wondering, how different could I be and still be a cat?' },
     { speaker: 'rabbit', text: 'Interesting question! What makes us who or what we are?' },
@@ -185,7 +188,11 @@ function setCharacterState(name, speaking, pose) {
     if (speaking) {
       ch.setState(pose || 'in-egg-open');
     } else {
-      ch.setState('default');
+      if (dialoguesPlayed['radioRoom']) {
+        ch.setState('in-egg-open');
+      } else {
+        ch.setState('default');
+      }
     }
     return;
   }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -129,6 +129,7 @@ let backBtn;
 let sceneHistory = [currentScene];
 let dogHouseVisits = 0;
 let pond2Visits = 0;
+let radioRoomVisits = 0;
 
 function preload() {
   if (typeof preloadSounds === 'function') preloadSounds();
@@ -509,6 +510,9 @@ function draw() {
     if (currentScene === 'pond2') {
       pond2Visits++;
     }
+    if (currentScene === 'radioRoom') {
+      radioRoomVisits++;
+    }
     if (currentScene === 'loft') {
       dialoguesPlayed['loft'] = false;
     }
@@ -567,6 +571,21 @@ function draw() {
         dog.setState('default');
       }
       playDialogue('dogHouseReturn');
+    }
+  }
+  if (!isDialogueActive() && currentScene === 'radioRoom') {
+    if (!dialoguesPlayed['radioRoom']) {
+      playDialogue('radioRoom', () => {
+        if (sceneCharacterSettings['radioRoom'] && sceneCharacterSettings['radioRoom'].chick) {
+          sceneCharacterSettings['radioRoom'].chick.state = 'in-egg-open';
+        }
+        if (typeof chick !== 'undefined') {
+          chick.baseState = 'in-egg-open';
+          chick.setState('in-egg-open');
+        }
+      });
+    } else if (radioRoomVisits > 1 && !dialoguesPlayed['radioRoomReturn']) {
+      playDialogue('radioRoomReturn');
     }
   }
   if (!isDialogueActive() && currentScene === 'loft' && !dialoguesPlayed['loft']) {


### PR DESCRIPTION
## Summary
- keep chick opened after the radio room is finished
- add dialogue when returning to the radio room
- track radio room visits and play the return dialogue

## Testing
- `npm test`
- `npm run check-assets`
