### PR TITLE
Add revisit dialogue and adjust scene assets

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -129,6 +129,9 @@ const dialogues = {
     { speaker: 'duck', text: 'Paint and canvas! How fun!' },
     { speaker: 'rabbit', text: 'What kind of art do you like to make?' }
   ],
+  studioReturn: [
+    { speaker: 'rabbit', text: 'Have you thought about what art you want to make?' }
+  ],
   mirror: [
     { speaker: 'duck', text: "Look, it's you! You're special!" },
     { speaker: 'rabbit', text: 'Yes, uniquely wonderful!' }
@@ -150,6 +153,9 @@ const dialogues = {
     { speaker: 'duck', text: 'If you barked, I think you would be a dog!'},
     { speaker: 'rabbit', text: "That is not true- some rodents bark! That doesn't make them dogs."},
       {speaker: 'graytortiecat', text: "Hmm, I don't know if there's an easy answer to this, but keep thinking about it and let me know if you have any ideas!"}
+  ],
+  loftEntranceReturn: [
+    { speaker: 'graytortiecat', text: "I still don't know exactly what makes me a cat! Maybe it's because my parents were cats, and their parents were cats..." }
   ],
   loft: [
     {

--- a/js/letters.js
+++ b/js/letters.js
@@ -121,7 +121,7 @@ function preloadLetters() {
     concept: 'Observation',
     description: 'Watching carefully to learn.',
     question: 'What have you discovered by observing?',
-    x: 560, y: 395
+    x: 570, y: 405
   });
   letters.push({
     scene: 'farmMap',

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -121,8 +121,8 @@ sceneCharacterSettings['greenhouse'].duck = { x: 340, y: 420 };
 sceneCharacterSettings['greenhouse'].rabbit = { x: 400 };
 
 // In the pond they appear roughly in the middle of the screen
-sceneCharacterSettings['pond'].duck   = { x: 360, y: 280, size: 100 };
-sceneCharacterSettings['pond'].rabbit = { x: 420, y: 280, size: 100 };
+sceneCharacterSettings['pond'].duck   = { x: 360, y: 250, size: 100 };
+sceneCharacterSettings['pond'].rabbit = { x: 420, y: 250, size: 100 };
 
 // Adjust positions in pond2: Rabbit sits in the top left and
 // Duck uses the swimming pose while remaining in its base position.
@@ -190,7 +190,7 @@ sceneCharacterSettings['swing'] = {
 sceneCharacterSettings['swing2'] = { pig: { x: 235, y: 220, size: 330 } };
 
 sceneCharacterSettings['radioRoom'] = {
-  chick: { x: 325, y: 320, state: 'default' },
+  chick: { x: 295, y: 320, state: 'default' },
   duck: { y: 500 }
 };
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -130,6 +130,8 @@ let sceneHistory = [currentScene];
 let dogHouseVisits = 0;
 let pond2Visits = 0;
 let radioRoomVisits = 0;
+let loftEntranceVisits = 0;
+let studioVisits = 0;
 
 function preload() {
   if (typeof preloadSounds === 'function') preloadSounds();
@@ -513,6 +515,12 @@ function draw() {
     if (currentScene === 'radioRoom') {
       radioRoomVisits++;
     }
+    if (currentScene === 'loftEntrance') {
+      loftEntranceVisits++;
+    }
+    if (currentScene === 'studio') {
+      studioVisits++;
+    }
     if (currentScene === 'loft') {
       dialoguesPlayed['loft'] = false;
     }
@@ -589,6 +597,20 @@ function draw() {
       });
     } else if (radioRoomVisits > 1 && !dialoguesPlayed['radioRoomReturn']) {
       playDialogue('radioRoomReturn');
+    }
+  }
+  if (!isDialogueActive() && currentScene === 'loftEntrance') {
+    if (!dialoguesPlayed['loftEntrance']) {
+      playDialogue('loftEntrance');
+    } else if (loftEntranceVisits > 1 && !dialoguesPlayed['loftEntranceReturn']) {
+      playDialogue('loftEntranceReturn');
+    }
+  }
+  if (!isDialogueActive() && currentScene === 'studio') {
+    if (!dialoguesPlayed['studio']) {
+      playDialogue('studio');
+    } else if (studioVisits > 1 && !dialoguesPlayed['studioReturn']) {
+      playDialogue('studioReturn');
     }
   }
   if (!isDialogueActive() && currentScene === 'loft' && !dialoguesPlayed['loft']) {


### PR DESCRIPTION
## Summary
- tweak pond & radio room character positions
- move radio room letter O
- add return dialogues for Studio and Loft Entrance
- track visits and trigger new lines on revisit

## Testing
- `npm run check-assets`