### PR TITLE
Update greenhouse link and dialogue

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -52,6 +52,15 @@ const dialogues = {
     { speaker: 'rabbit', text: 'Okay! We\'ll hand water the other tray tomorrow.' },
     { speaker: 'duck', text: 'Every plant will get its turn to grow.' }
   ],
+  greenhouseInsideReturn: [
+    { speaker: 'rabbit', text: 'Those 10 plants have had water for a while now. Should we leave them there, or switch them back?' }
+  ],
+  greenhouseInsideReturn_trayA: [
+    { speaker: 'duck', text: 'We will make sure all of the plants get the T.L.C. they need, one way or another!' }
+  ],
+  greenhouseInsideReturn_trayB: [
+    { speaker: 'duck', text: 'We will make sure all of the plants get the T.L.C. they need, one way or another!' }
+  ],
   vegetables: [
     { speaker: 'duck', text: "I'm getting hungry." },
     { speaker: 'rabbit', text: 'Let\'s grab a tasty treat from my tunnels beneath the garden.' }

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -57,7 +57,7 @@ function setupScenes() {
     {name: 'dogHouse', label: 'doghouse', x: 30,  y: 30,  w: 50,  h: 50, labelY: 95},
     {name: 'bench', label: 'bench', x: 20,  y: 370, w: 70,  h: 70},
     {name: 'pond', label: 'pond', x: 450, y: 380, w: 100, h: 100},
-    {name: 'greenhouse', label: 'greenhouse', x: 500, y: 175, w: 50,  h: 50, labelY: 185},
+    {name: 'greenhouseInside', label: 'greenhouse', x: 500, y: 175, w: 50,  h: 50, labelY: 185},
     {name: 'picnic', label: 'picnic', x: 700, y: 140, w: 50,  h: 50},
     {name: 'vegetables', label: 'vegetables', x: 715, y: 300, w: 50, h: 50},
     {name: 'flowers', label: 'birdhouse', x: 40, y: 250, w: 80, h: 80}
@@ -167,7 +167,7 @@ function handleSceneClicks(mx, my) {
     const letterEFound =
       typeof isLetterFound === 'function' &&
       isLetterFound('E', 'greenhouseInside');
-    const promptShown = dialoguesPlayed['greenhouseInside'];
+    const promptShown = dialoguesPlayed['greenhouseInside'] || dialoguesPlayed['greenhouseInsideReturn'];
     if (!letterEFound || !promptShown) {
       return;
     }
@@ -196,8 +196,12 @@ function handleSceneClicks(mx, my) {
         trayOnTable = 'trayA';
         trayA.reset();
         trayB.reset();
-        if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayA']) {
-          playDialogue('greenhouseInside_trayA');
+        if (typeof playDialogue === 'function') {
+          if (dialoguesPlayed['greenhouseInsideReturn']) {
+            playDialogue('greenhouseInsideReturn_trayA');
+          } else {
+            playDialogue('greenhouseInside_trayA');
+          }
         }
         trayChoiceMade = true;
         clicked = true;
@@ -207,8 +211,12 @@ function handleSceneClicks(mx, my) {
         trayOnTable = 'trayB';
         trayA.reset();
         trayB.reset();
-        if (typeof playDialogue === 'function' && !dialoguesPlayed['greenhouseInside_trayB']) {
-          playDialogue('greenhouseInside_trayB');
+        if (typeof playDialogue === 'function') {
+          if (dialoguesPlayed['greenhouseInsideReturn']) {
+            playDialogue('greenhouseInsideReturn_trayB');
+          } else {
+            playDialogue('greenhouseInside_trayB');
+          }
         }
         trayChoiceMade = true;
         clicked = true;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -132,6 +132,7 @@ let pond2Visits = 0;
 let radioRoomVisits = 0;
 let loftEntranceVisits = 0;
 let studioVisits = 0;
+let greenhouseInsideVisits = 0;
 
 function preload() {
   if (typeof preloadSounds === 'function') preloadSounds();
@@ -528,13 +529,20 @@ function draw() {
       dialoguesPlayed['swing'] = false;
     }
     if (currentScene === 'greenhouseInside') {
+      greenhouseInsideVisits++;
       trayChoiceMade = false;
-      trayOnTable = 'trayB';
+      dialoguesPlayed['greenhouseInside'] = false;
+      dialoguesPlayed['greenhouseInsideReturn'] = false;
+      if (greenhouseInsideVisits === 1) {
+        trayOnTable = 'trayB';
+        if (typeof trayA !== 'undefined' && typeof trayB !== 'undefined') {
+          trayA.baseX = 470;
+          trayA.baseY = 420;
+          trayB.baseX = 345;
+          trayB.baseY = 420;
+        }
+      }
       if (typeof trayA !== 'undefined' && typeof trayB !== 'undefined') {
-        trayA.baseX = 470;
-        trayA.baseY = 420;
-        trayB.baseX = 345;
-        trayB.baseY = 420;
         sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX;
         sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY;
         sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX;
@@ -611,6 +619,18 @@ function draw() {
       playDialogue('studio');
     } else if (studioVisits > 1 && !dialoguesPlayed['studioReturn']) {
       playDialogue('studioReturn');
+    }
+  }
+  if (!isDialogueActive() && currentScene === 'greenhouseInside') {
+    if (
+      greenhouseInsideVisits > 1 &&
+      trayOnTable === 'trayA' &&
+      !dialoguesPlayed['greenhouseInsideReturn']
+    ) {
+      dialoguesPlayed['greenhouseInside'] = true;
+      playDialogue('greenhouseInsideReturn');
+    } else if (!dialoguesPlayed['greenhouseInside']) {
+      playDialogue('greenhouseInside');
     }
   }
   if (!isDialogueActive() && currentScene === 'loft' && !dialoguesPlayed['loft']) {


### PR DESCRIPTION
## Summary
- link farm map greenhouse text directly to `greenhouseInside`
- add return dialogue options for greenhouseInside
- keep tray positions when revisiting greenhouseInside
- repeat tray choice dialogue as needed

## Testing
- `npm run check-assets`