### PR TITLE
Update continue button handling

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -314,10 +314,12 @@ function playDialogue(scene, callback) {
 
 function stopDialogue() {
   const box = document.getElementById('dialogueBox');
+  const continueBtn = document.getElementById('continueBtn');
   if (box) {
     box.style.display = 'none';
     box.onclick = null;
   }
+  if (continueBtn) continueBtn.style.display = 'none';
   if (currentSpeaker) {
     setCharacterState(currentSpeaker, false);
     currentSpeaker = null;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -919,6 +919,10 @@ function updateBenchRestDialogue() {
 }
 
 function advanceScene() {
+  if (currentScene === 'farmMap') {
+    if (continueBtn) continueBtn.style.display = 'none';
+    return;
+  }
   if (typeof playSound === 'function') playSound('continue');
   if (currentScene === 'donkey') {
     if (typeof playSound === 'function') playSound('transition');


### PR DESCRIPTION
## Summary
- hide the continue button whenever dialogue is stopped
- prevent advancing scenes directly from the map screen

## Testing
- `npm test`
- `npm run check-assets`
