### PR TITLE
Update dog state transitions

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -95,10 +95,10 @@ const dialogues = {
   ],
   dogHouse: [
     { speaker: 'rabbit', text: "Oh no, Dog, are you okay?" },
-    { speaker: 'dog', text: "I'm sad; people say I look like a pitbull, or dalmation, or herding dog, and assume I'm dangerous because of it.", pose: 'sad' },
+    { speaker: 'dog', text: "I'm sad; people say I look like a pitbull, or dalmation, or herding dog, and assume I'm dangerous because of it.", pose: 'sad-talking' },
     { speaker: 'duck', text: "That's just like when I thought shadows were reality. I judged too quickly by appearances, but that's wrong to do." },
-    { speaker: 'rabbit', text: "We won't judge you too quickly- we'd love to be your friends!" },
-    { speaker: 'dog', text: 'Really? Thank you!' }
+    { speaker: 'rabbit', text: "We won't judge you too quickly- we'd love to be your friends!", actions: { dog: 'default' } },
+    { speaker: 'dog', text: 'Really? Thank you!', pose: 'default' }
   ],
   dogHouseReturn: [
     { speaker: 'dog', text: 'Hi Duck and Rabbit! Thank you for being my friends!', pose: 'happy' }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -162,7 +162,7 @@ function preload() {
   donkey.state = 'mouth-closed';
   donkey.initBase();
 
-  dog = new Character('dog', ['happy', 'sad', 'mouth-closed'], 100, 620, 440);
+  dog = new Character('dog', ['happy', 'sad', 'sad-talking', 'mouth-closed'], 100, 620, 440);
   dog.images['idle'] = loadImage('assets/images/dog/default.png');
   dog.state = 'mouth-closed';
   dog.initBase();


### PR DESCRIPTION
## Summary
- add `sad-talking` pose for the dog on initialization
- adjust `dogHouse` dialogue so the dog starts talking sadly and then returns to the default pose
- leave existing callback that restores the dog to default state after the scene

## Testing
- `npm test`
- `npm run check-assets`
