### PR TITLE
Reset return dialogues on scene entry

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -510,18 +510,22 @@ function draw() {
     sceneHistory.push(currentScene);
     if (currentScene === 'dogHouse') {
       dogHouseVisits++;
+      dialoguesPlayed['dogHouseReturn'] = false;
     }
     if (currentScene === 'pond2') {
       pond2Visits++;
     }
     if (currentScene === 'radioRoom') {
       radioRoomVisits++;
+      dialoguesPlayed['radioRoomReturn'] = false;
     }
     if (currentScene === 'loftEntrance') {
       loftEntranceVisits++;
+      dialoguesPlayed['loftEntranceReturn'] = false;
     }
     if (currentScene === 'studio') {
       studioVisits++;
+      dialoguesPlayed['studioReturn'] = false;
     }
     if (currentScene === 'donkey') {
       donkeyVisits++;


### PR DESCRIPTION
## Summary
- reset return dialogue flags when entering scenes so they can play once per visit

## Testing
- `npm test`
- `npm run check-assets`
