### PR TITLE
Add vegetables return dialogue logic

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -65,6 +65,9 @@ const dialogues = {
     { speaker: 'duck', text: "I'm getting hungry." },
     { speaker: 'rabbit', text: 'Let\'s grab a tasty treat from my tunnels beneath the garden.' }
   ],
+  vegetablesReturn: [
+    { speaker: 'rabbit', text: "Do you want to go back to the map and figure out where to go from here?" }
+  ],
   tunnel: [
     { speaker: 'rabbit', text: 'I think those vegetables are around here somewhere...' }
   ],

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -134,6 +134,7 @@ let loftEntranceVisits = 0;
 let studioVisits = 0;
 let greenhouseInsideVisits = 0;
 let donkeyVisits = 0;
+let vegetablesVisits = 0;
 
 function preload() {
   if (typeof preloadSounds === 'function') preloadSounds();
@@ -530,6 +531,10 @@ function draw() {
     if (currentScene === 'donkey') {
       donkeyVisits++;
     }
+    if (currentScene === 'vegetables') {
+      vegetablesVisits++;
+      dialoguesPlayed['vegetablesReturn'] = false;
+    }
     if (currentScene === 'loft') {
       dialoguesPlayed['loft'] = false;
     }
@@ -646,6 +651,13 @@ function draw() {
       playDialogue('greenhouseInsideReturn');
     } else if (!dialoguesPlayed['greenhouseInside']) {
       playDialogue('greenhouseInside');
+    }
+  }
+  if (!isDialogueActive() && currentScene === 'vegetables') {
+    if (!dialoguesPlayed['vegetables']) {
+      playDialogue('vegetables');
+    } else if (vegetablesVisits > 1 && !dialoguesPlayed['vegetablesReturn']) {
+      playDialogue('vegetablesReturn');
     }
   }
   if (!isDialogueActive() && isLetterFound('Z') && currentScene === 'loft' && !dialoguesPlayed['loft']) {


### PR DESCRIPTION
## Summary
- add a `vegetablesReturn` dialogue
- count visits to the vegetables scene
- trigger a return dialogue on repeat visits

## Testing
- `npm run check-assets`