### PR TITLE
Add picnic return dialogue

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -81,6 +81,9 @@ const dialogues = {
     { speaker: 'duck', text: 'We have a heap of vegetables! Would you like to eat a healthy snack with us?' },
     { speaker: 'rabbit', text: "I wonder how much we have to eat before it's no longer a heap!" }
   ],
+  picnicReturn: [
+    { speaker: 'rabbit', text: "I'm not sure if I'm hungry anymore, but if you are, you should grab a healthy snack!" }
+  ],
   farmMap: [
     { speaker: 'duck', text: "There's still so much to see." },
     { speaker: 'rabbit', text: 'Click around the map to revisit or explore new areas!' }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -134,6 +134,7 @@ let loftEntranceVisits = 0;
 let studioVisits = 0;
 let greenhouseInsideVisits = 0;
 let donkeyVisits = 0;
+let picnicVisits = 0;
 
 function preload() {
   if (typeof preloadSounds === 'function') preloadSounds();
@@ -530,6 +531,10 @@ function draw() {
     if (currentScene === 'donkey') {
       donkeyVisits++;
     }
+    if (currentScene === 'picnic') {
+      picnicVisits++;
+      dialoguesPlayed['picnicReturn'] = false;
+    }
     if (currentScene === 'loft') {
       dialoguesPlayed['loft'] = false;
     }
@@ -653,6 +658,13 @@ function draw() {
   }
   if (!isDialogueActive() && isLetterFound('G') && currentScene === 'swing' && !dialoguesPlayed['swing']) {
     playDialogue('swing');
+  }
+  if (!isDialogueActive() && currentScene === 'picnic') {
+    if (!dialoguesPlayed['picnic']) {
+      playDialogue('picnic');
+    } else if (picnicVisits > 1 && !dialoguesPlayed['picnicReturn']) {
+      playDialogue('picnicReturn');
+    }
   }
   if (
     !isDialogueActive() &&


### PR DESCRIPTION
## Summary
- expand dialogue with `picnicReturn`
- track number of picnic visits
- trigger `picnicReturn` dialogue on repeat visits

## Testing
- `npm test`
- `npm run check-assets`
