### PR TITLE
Update donkey positions and block vegetable continue

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -290,7 +290,8 @@ function playDialogue(scene, callback) {
           scene === 'barn' ||
           scene === 'bench' ||
           scene === 'benchIntro' ||
-          scene === 'benchRest'
+          scene === 'benchRest' ||
+          scene === 'vegetables'
         ) {
           continueBtn.style.display = 'none';
         } else {

--- a/js/letters.js
+++ b/js/letters.js
@@ -105,7 +105,7 @@ function preloadLetters() {
     concept: 'Minds',
     description: 'Our memories, feelings, thoughts, and experiences are part of our minds... Only you can access yours!',
     question: 'Do other animals think and feel like we do?',
-    x: 430, y: 165
+    x: 415, y: 165
   });
   letters.push({
     scene: 'pond',

--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -171,9 +171,9 @@ sceneCharacterSettings['barn'] = {
 };
 
 sceneCharacterSettings['donkey'] = {
-  donkey: { x: 300, y: 200, size: 440 },
-  duck: { x: 130, y: 350, size: 100 },
-  rabbit: { x: 190, y: 350, size: 100 },
+  donkey: { x: 100, y: 200, size: 440 },
+  duck: { x: 560, y: 500, size: 100 },
+  rabbit: { x: 620, y: 500, size: 100 },
   orangecat: { x: 0, y: 300, size: 100 }
 };
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -714,7 +714,7 @@ function draw() {
     });
   }
   if (currentScene === 'donkey') {
-    image(barnIcon, 50, 260, 50, 50);
+    image(barnIcon, 50, 160, 50, 50);
   }
   if (
     mapUnlocked &&
@@ -839,7 +839,7 @@ function mousePressed() {
     }
   }
   if (currentScene === 'donkey') {
-    if (mouseX >= 50 && mouseX <= 100 && mouseY >= 260 && mouseY <= 310) {
+    if (mouseX >= 50 && mouseX <= 100 && mouseY >= 160 && mouseY <= 210) {
       if (typeof playSound === 'function') playSound('click');
       if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'barn';


### PR DESCRIPTION
## Summary
- shift the letter M left in the tunnel
- reposition donkey scene characters and barn icon
- keep continue button hidden for the vegetables scene

## Testing
- `npm test`