### PR TITLE
Fix continue button after vegetables scene

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -291,7 +291,7 @@ function playDialogue(scene, callback) {
           scene === 'bench' ||
           scene === 'benchIntro' ||
           scene === 'benchRest' ||
-          scene === 'vegetables'
+          scene === 'vegetablesReturn'
         ) {
           continueBtn.style.display = 'none';
         } else {


### PR DESCRIPTION
## Summary
- show Continue button after first visit to vegetables
- hide button after returning from vegetables
- validate referenced assets

## Testing
- `npm run check-assets`