### PR TITLE
Add return dialogues for field and mirror scenes

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -114,6 +114,10 @@ const dialogues = {
     { speaker: 'sheep', text: "I don't think we are robots!" },
     { speaker: 'duck', text: 'Hmm, you kind of look like fake sheep to me...' }
   ],
+  fieldReturn: [
+    { speaker: 'sheep', text: 'Baa! Nice to see you again in the field!' },
+    { speaker: 'rabbit', text: 'These sheep remember us!' }
+  ],
   barn: [
     { speaker: 'duck', text: 'Should we talk to Donkey, explore the barn, or look at the map?' },
     { speaker: 'rabbit', text: 'You decide!' }
@@ -154,6 +158,10 @@ const dialogues = {
   mirror: [
     { speaker: 'duck', text: "Look, it's you! You're special!" },
     { speaker: 'rabbit', text: 'Yes, uniquely wonderful!' }
+  ],
+  mirrorReturn: [
+    { speaker: 'duck', text: 'Still you in the mirror!' },
+    { speaker: 'rabbit', text: 'Always unique!' }
   ],
   radioRoom: [
     { speaker: 'radio', text: '...and that concludes our podcast on The Complete Physical Account of Color Vision.'},

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -136,6 +136,8 @@ let greenhouseInsideVisits = 0;
 let donkeyVisits = 0;
 let picnicVisits = 0;
 let vegetablesVisits = 0;
+let fieldVisits = 0;
+let mirrorVisits = 0;
 
 function preload() {
   if (typeof preloadSounds === 'function') preloadSounds();
@@ -542,6 +544,14 @@ function draw() {
       vegetablesVisits++;
       dialoguesPlayed['vegetablesReturn'] = false;
     }
+    if (currentScene === 'field') {
+      fieldVisits++;
+      dialoguesPlayed['fieldReturn'] = false;
+    }
+    if (currentScene === 'mirror') {
+      mirrorVisits++;
+      dialoguesPlayed['mirrorReturn'] = false;
+    }
     if (currentScene === 'loft') {
       dialoguesPlayed['loft'] = false;
     }
@@ -627,6 +637,13 @@ function draw() {
       playDialogue('donkeyReturn');
     }
   }
+  if (!isDialogueActive() && !pendingDialogueScene && isLetterFound('K') && currentScene === 'field') {
+    if (!dialoguesPlayed['field']) {
+      playDialogue('field');
+    } else if (fieldVisits > 1 && !dialoguesPlayed['fieldReturn']) {
+      playDialogue('fieldReturn');
+    }
+  }
   if (!isDialogueActive() && !pendingDialogueScene && isLetterFound('O') && currentScene === 'radioRoom') {
     if (!dialoguesPlayed['radioRoom']) {
       playDialogue('radioRoom', () => {
@@ -662,6 +679,13 @@ function draw() {
       playDialogue('studio');
     } else if (studioVisits > 1 && !dialoguesPlayed['studioReturn']) {
       playDialogue('studioReturn');
+    }
+  }
+  if (!isDialogueActive() && !pendingDialogueScene && isLetterFound('Y') && currentScene === 'mirror') {
+    if (!dialoguesPlayed['mirror']) {
+      playDialogue('mirror');
+    } else if (mirrorVisits > 1 && !dialoguesPlayed['mirrorReturn']) {
+      playDialogue('mirrorReturn');
     }
   }
   if (!isDialogueActive() && !pendingDialogueScene && isLetterFound('E', 'greenhouseInside') && currentScene === 'greenhouseInside') {


### PR DESCRIPTION
## Summary
- add 'fieldReturn' dialogue and new text lines
- add 'mirrorReturn' dialogue and new text lines
- track visits for field and mirror scenes
- trigger return dialogues when revisiting field or mirror

## Testing
- `node -e "require('./js/dialogue.js'); console.log('ok');"`
- `node -e "require('./js/sketch.js');"`