### PR TITLE
Fix dialogue click handling

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -888,8 +888,9 @@ function draw() {
 }
 
 function mousePressed() {
+  // When dialogue is active, let the dialogue box handle clicks to
+  // advance the conversation instead of closing it immediately.
   if (isDialogueActive()) {
-    if (typeof stopDialogue === 'function') stopDialogue();
     return;
   }
   const infoBox = document.getElementById('letterInfoBox');


### PR DESCRIPTION
## Summary
- prevent dialogue from closing when clicked
- ensure clicking progresses dialogue

## Testing
- `npm run check-assets`
