### PR TITLE
Handle flowers return to map

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1078,6 +1078,15 @@ function advanceScene() {
     continueBtn.style.display = 'none';
     return;
   }
+  if (currentScene === 'flowers' && flowersVisits > 1) {
+    if (typeof playSound === 'function') playSound('transition');
+    if (typeof stopDialogue === 'function') stopDialogue();
+    if (typeof hideLetterInfo === 'function') hideLetterInfo();
+    currentScene = 'farmMap';
+    sceneIndex = orderedScenes.indexOf('farmMap');
+    continueBtn.style.display = 'none';
+    return;
+  }
   sceneIndex++;
   if (sceneIndex >= orderedScenes.length) {
     continueBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- jump to farm map after revisiting the flower scene
- keep the Continue button visible after `flowersReturn`

## Testing
- `npm run check-assets`
