### PR TITLE
Scale characters on resize

### DIFF
--- a/js/sceneCharacters.js
+++ b/js/sceneCharacters.js
@@ -1,3 +1,8 @@
+// Base design resolution.  Character positions are defined relative to these
+// values and scaled in sketch.js at runtime.
+const BASE_W = 800;
+const BASE_H = 600;
+
 // Characters present in each scene
 // Keys are scene names and values are arrays of character variable names
 const defaultScenes = [

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -259,6 +259,8 @@ function drawSceneCharacters(scene) {
         sceneCharacterSettings[scene] &&
         sceneCharacterSettings[scene][name];
 
+      const scale = typeof getCanvasScale === 'function' ? getCanvasScale() : 1;
+
       if (charObj.lastScene !== scene) {
         const base = basePositions[name] || {
           x: charObj.baseX,
@@ -266,9 +268,12 @@ function drawSceneCharacters(scene) {
           size: charObj.baseSize,
           state: charObj.baseState
         };
-        charObj.baseX = overrides && overrides.x !== undefined ? overrides.x : base.x;
-        charObj.baseY = overrides && overrides.y !== undefined ? overrides.y : base.y;
-        charObj.baseSize = overrides && overrides.size !== undefined ? overrides.size : base.size;
+        const baseX = overrides && overrides.x !== undefined ? overrides.x : base.x;
+        const baseY = overrides && overrides.y !== undefined ? overrides.y : base.y;
+        const baseSize = overrides && overrides.size !== undefined ? overrides.size : base.size;
+        charObj.baseX = baseX * scale;
+        charObj.baseY = baseY * scale;
+        charObj.baseSize = baseSize * scale;
         const state = overrides && overrides.state !== undefined ? overrides.state : base.state;
         const activeDialogue = typeof isDialogueActive === 'function' && isDialogueActive();
         if (!activeDialogue && state && typeof charObj.setState === 'function') {
@@ -283,9 +288,9 @@ function drawSceneCharacters(scene) {
       }
 
       if (overrides) {
-        if (overrides.x !== undefined) charObj.x = overrides.x;
-        if (overrides.y !== undefined) charObj.y = overrides.y;
-        if (overrides.size !== undefined) charObj.size = overrides.size;
+        if (overrides.x !== undefined) charObj.x = overrides.x * scale;
+        if (overrides.y !== undefined) charObj.y = overrides.y * scale;
+        if (overrides.size !== undefined) charObj.size = overrides.size * scale;
       }
       // Mark interactive characters for hover effects
       charObj.interactive = false;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -473,6 +473,10 @@ function getCanvasSize() {
   return { w, h };
 }
 
+function getCanvasScale() {
+  return width / (typeof BASE_W !== 'undefined' ? BASE_W : width);
+}
+
 function applyCanvasSize() {
   const { w, h } = getCanvasSize();
   resizeCanvas(w, h);
@@ -483,6 +487,14 @@ function applyCanvasSize() {
       l.y = l.bottomY;
     }
   });
+  if (typeof basePositions !== 'undefined') {
+    Object.keys(basePositions).forEach(name => {
+      const obj = window[name];
+      if (obj && obj.lastScene !== undefined) {
+        obj.lastScene = null;
+      }
+    });
+  }
 }
 
 function setup() {


### PR DESCRIPTION
## Summary
- add BASE_W and BASE_H constants for design resolution
- compute a canvas scale factor
- scale character positions in `drawSceneCharacters`
- reset characters when canvas resizes

## Testing
- `npm run check-assets`
- `npm test`
