### PR TITLE
Add scaling for letters and interactive areas

### DIFF
--- a/js/letters.js
+++ b/js/letters.js
@@ -221,7 +221,17 @@ function preloadLetters() {
     l.found = false;
     l.size = 32;
     l.baseSize = 32;
+    l.baseX = l.x;
+    l.baseY = l.y;
     l.answer = '';
+  });
+}
+
+function scaleLetters(scale) {
+  letters.forEach(l => {
+    l.x = l.baseX * scale;
+    l.y = l.baseY * scale;
+    l.size = l.baseSize * scale;
   });
 }
 
@@ -491,5 +501,6 @@ function showContinueForDialogue(scene) {
 
 if (typeof window !== 'undefined') {
   window.hideLetterInfo = hideLetterInfo;
+  window.scaleLetters = scaleLetters;
 }
 

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -63,6 +63,15 @@ function setupScenes() {
     {name: 'flowers', label: 'birdhouse', x: 40, y: 250, w: 80, h: 80}
   ];
 
+  scenes.interactiveAreas.forEach(a => {
+    a.baseX = a.x;
+    a.baseY = a.y;
+    a.baseW = a.w;
+    a.baseH = a.h;
+    if (a.labelX !== undefined) a.baseLabelX = a.labelX;
+    if (a.labelY !== undefined) a.baseLabelY = a.labelY;
+  });
+
   // Interactive areas inside the barn
   scenes.barnInsideAreas = [
     {name: 'mirror', label: 'mirror', x: 120,  y: 350, w: 100, h: 100},
@@ -70,6 +79,38 @@ function setupScenes() {
     {name: 'loftEntrance', label: 'loft entrance', x: 640, y: 350, w: 100, h: 100, labelX: 680},
     {name: 'studio', label: 'studio', x: 690, y: 450, w: 100, h: 100, labelX: 745}
   ];
+
+  scenes.barnInsideAreas.forEach(a => {
+    a.baseX = a.x;
+    a.baseY = a.y;
+    a.baseW = a.w;
+    a.baseH = a.h;
+    if (a.labelX !== undefined) a.baseLabelX = a.labelX;
+    if (a.labelY !== undefined) a.baseLabelY = a.labelY;
+  });
+}
+
+function scaleInteractiveAreas(scale) {
+  if (Array.isArray(scenes.interactiveAreas)) {
+    scenes.interactiveAreas.forEach(a => {
+      a.x = a.baseX * scale;
+      a.y = a.baseY * scale;
+      a.w = a.baseW * scale;
+      a.h = a.baseH * scale;
+      if (a.baseLabelX !== undefined) a.labelX = a.baseLabelX * scale;
+      if (a.baseLabelY !== undefined) a.labelY = a.baseLabelY * scale;
+    });
+  }
+  if (Array.isArray(scenes.barnInsideAreas)) {
+    scenes.barnInsideAreas.forEach(a => {
+      a.x = a.baseX * scale;
+      a.y = a.baseY * scale;
+      a.w = a.baseW * scale;
+      a.h = a.baseH * scale;
+      if (a.baseLabelX !== undefined) a.labelX = a.baseLabelX * scale;
+      if (a.baseLabelY !== undefined) a.labelY = a.baseLabelY * scale;
+    });
+  }
 }
 
 function drawScene(scene) {
@@ -314,4 +355,8 @@ function drawSceneCharacters(scene) {
       charObj.display();
     }
   });
+}
+
+if (typeof window !== 'undefined') {
+  window.scaleInteractiveAreas = scaleInteractiveAreas;
 }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -480,6 +480,13 @@ function getCanvasScale() {
 function applyCanvasSize() {
   const { w, h } = getCanvasSize();
   resizeCanvas(w, h);
+  const scale = getCanvasScale();
+  if (typeof scaleLetters === 'function') {
+    scaleLetters(scale);
+  }
+  if (typeof scaleInteractiveAreas === 'function') {
+    scaleInteractiveAreas(scale);
+  }
   initLetterBottomPositions();
   letters.forEach(l => {
     if (l.found) {
@@ -500,8 +507,21 @@ function applyCanvasSize() {
 function setup() {
   const { w, h } = getCanvasSize();
   createCanvas(w, h);
-  initLetterBottomPositions();
+  const scale = getCanvasScale();
+  if (typeof scaleLetters === 'function') {
+    scaleLetters(scale);
+  }
   setupScenes();
+  if (typeof scaleInteractiveAreas === 'function') {
+    scaleInteractiveAreas(scale);
+  }
+  initLetterBottomPositions();
+  letters.forEach(l => {
+    if (l.found) {
+      l.x = l.bottomX;
+      l.y = l.bottomY;
+    }
+  });
   continueBtn = document.getElementById('continueBtn');
   continueBtn.addEventListener('click', advanceScene);
   // Start with the continue button hidden; it will be shown


### PR DESCRIPTION
## Summary
- store base letter coordinates and implement `scaleLetters`
- store base interactive area coordinates and implement `scaleInteractiveAreas`
- resize letters and interactive areas in `applyCanvasSize` and `setup`
- export the new scaling helpers

## Testing
- `npm run check-assets`