### PR TITLE
Fix tray scaling in greenhouse scene

### DIFF
--- a/js/scenes.js
+++ b/js/scenes.js
@@ -226,10 +226,12 @@ function handleSceneClicks(mx, my) {
         trayA.baseY = trayB.baseY;
         trayB.baseX = tX;
         trayB.baseY = tY;
-        sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX;
-        sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY;
-        sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX;
-        sceneCharacterSettings['greenhouseInside'].trayB.y = trayB.baseY;
+        const scale =
+          typeof getCanvasScale === 'function' ? getCanvasScale() : 1;
+        sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX / scale;
+        sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY / scale;
+        sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX / scale;
+        sceneCharacterSettings['greenhouseInside'].trayB.y = trayB.baseY / scale;
       };
       if (withinTrayA) {
         if (typeof playSound === 'function') playSound('click');

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -678,10 +678,12 @@ function draw() {
         }
       }
       if (typeof trayA !== 'undefined' && typeof trayB !== 'undefined') {
-        sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX;
-        sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY;
-        sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX;
-        sceneCharacterSettings['greenhouseInside'].trayB.y = trayB.baseY;
+        const scale =
+          typeof getCanvasScale === 'function' ? getCanvasScale() : 1;
+        sceneCharacterSettings['greenhouseInside'].trayA.x = trayA.baseX / scale;
+        sceneCharacterSettings['greenhouseInside'].trayA.y = trayA.baseY / scale;
+        sceneCharacterSettings['greenhouseInside'].trayB.x = trayB.baseX / scale;
+        sceneCharacterSettings['greenhouseInside'].trayB.y = trayB.baseY / scale;
         trayA.reset();
         trayB.reset();
       }


### PR DESCRIPTION
## Summary
- fix swapped tray coordinates from being double-scaled
- store unscaled tray positions when scene loads and when trays swap

## Testing
- `npm run check-assets`