### PR TITLE
Keep dog happy after reassurance

### DIFF
--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -106,7 +106,7 @@ const dialogues = {
     { speaker: 'rabbit', text: "Oh no, Dog, are you okay?" },
     { speaker: 'dog', text: "I'm sad; people say I look like a pitbull, or dalmation, or herding dog, and assume I'm dangerous because of it.", pose: 'sad-talking' },
     { speaker: 'duck', text: "That's just like when I thought shadows were reality. I judged too quickly by appearances, but that's wrong to do." },
-    { speaker: 'rabbit', text: "We won't judge you too quickly- we'd love to be your friends!", actions: { dog: 'default' } },
+    { speaker: 'rabbit', text: "We won't judge you too quickly- we'd love to be your friends!", actions: { dog: 'happy' } },
     { speaker: 'dog', text: 'Really? Thank you!', pose: 'happy' }
   ],
   dogHouseReturn: [

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -719,28 +719,28 @@ function draw() {
     if (!dialoguesPlayed['dogHouse']) {
       playDialogue('dogHouse', () => {
         if (sceneCharacterSettings['dogHouse'] && sceneCharacterSettings['dogHouse'].dog) {
-          sceneCharacterSettings['dogHouse'].dog.state = 'default';
+          sceneCharacterSettings['dogHouse'].dog.state = 'happy';
         }
         if (typeof dog !== 'undefined') {
-          dog.baseState = 'default';
-          dog.setState('default');
+          dog.baseState = 'happy';
+          dog.setState('happy');
         }
       });
     } else if (dogHouseVisits > 1 && !dialoguesPlayed['dogHouseReturn']) {
       if (sceneCharacterSettings['dogHouse'] && sceneCharacterSettings['dogHouse'].dog) {
-        sceneCharacterSettings['dogHouse'].dog.state = 'default';
+        sceneCharacterSettings['dogHouse'].dog.state = 'happy';
       }
       if (typeof dog !== 'undefined') {
-        dog.baseState = 'default';
-        dog.setState('default');
+        dog.baseState = 'happy';
+        dog.setState('happy');
       }
       playDialogue('dogHouseReturn', () => {
         if (sceneCharacterSettings['dogHouse'] && sceneCharacterSettings['dogHouse'].dog) {
-          sceneCharacterSettings['dogHouse'].dog.state = 'default';
+          sceneCharacterSettings['dogHouse'].dog.state = 'happy';
         }
         if (typeof dog !== 'undefined') {
-          dog.baseState = 'default';
-          dog.setState('default');
+          dog.baseState = 'happy';
+          dog.setState('happy');
         }
       });
     }


### PR DESCRIPTION
## Summary
- Make dog immediately switch to a happy animation when Rabbit reassures him in the dogHouse dialogue.
- Ensure dog returns to and remains in a happy base state after dogHouse and dogHouseReturn scenes.

## Testing
- `npm test`
- `npm run check-assets`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1f21a8483228881a09724ede9fa