### PR TITLE
Add scene inquiry prompts and logging hook

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
   <!-- Inquiry moves + Reason trace -->
   <script src="js/moves.js"></script>
   <script src="js/trace.js"></script>
+  <script src="js/sceneDialogs.js"></script>
+  <script src="js/sceneInquiry.js"></script>
   <script src="js/scenes.js"></script>
   <script src="js/letters.js"></script>
   <script src="js/dialogue.js"></script>

--- a/js/letters.js
+++ b/js/letters.js
@@ -381,7 +381,7 @@ function showLetterInfo(letter) {
   html += (letter.description||'') + '<br><br>';
   html += '<em>'+starter+'</em>';
   html += _renderMoveButtons(opts);
-  html += '<input id="letterReasonInput" class="reason-input" type="text" maxlength="120" value="'+(letter.answer||'')+'" placeholder="Write your reason in one sentence…"/>';
+  html += '<input id="letterReasonInput" class="reason-input" type="text" aria-label="Your reason" maxlength="120" value="'+(letter.answer||'')+'" placeholder="Write your reason in one sentence…"/>';
   html += '<div class="confidence">';
   html += '<span>Confidence: </span>';
   html += '<label><input type="radio" name="conf" value="low"> Not sure</label>';
@@ -416,13 +416,30 @@ function showLetterInfo(letter) {
       letter.answer = reason; // keeps compatibility with Answers view
       try {
         if (typeof logReason === 'function') {
-          logReason({ sceneOrLetter: letter.letter, move: _selectedMoveId, reasonText: reason, confidence: _getConfidence() });
+          logReason({
+            sceneOrLetter: letter.letter,
+            concept: letter.concept || letter.title || '',
+            move: _selectedMoveId,
+            reasonText: reason,
+            confidence: _getConfidence(),
+            context: (letter._fromSceneId ? ('scene:'+letter._fromSceneId) : 'letter')
+          });
         }
         if (typeof scoreMove === 'function') { scoreMove(_selectedMoveId); }
         if (typeof renderBadges === 'function') { renderBadges(); }
+        // Optional callback so scenes can chain a pressure/revise step
+        if (typeof window.onAfterInquirySave === 'function') {
+          window.onAfterInquirySave({ letter, move: _selectedMoveId });
+        }
       } catch(e){}
       closeLetterInfo();
     };
+  }
+  // Keyboard: submit on Enter
+  if (input && saveBtn) {
+    input.addEventListener('keydown', function(e){
+      if (e.key === 'Enter') saveBtn.click();
+    });
   }
   if (closeBtn) { closeBtn.onclick = closeLetterInfo; }
 }

--- a/js/sceneDialogs.js
+++ b/js/sceneDialogs.js
@@ -1,0 +1,45 @@
+/* js/sceneDialogs.js — minimal micro-dialogue content for scenes */
+window.SCENE_DIALOGS = {
+  barnInside: [{
+    title: "Barn Bat",
+    concept: "Bat Feelings",
+    starter: "If you knew every fact about bats, would you know bat-feeling?",
+    options: [
+      { move: "reason",        text: "Yes—facts are enough, because…" },
+      { move: "reason",        text: "No—feeling is different, because…" },
+      { move: "question",      text: "What counts as ‘feeling’ here?" },
+      { move: "counterexample",text: "What about tasting a new fruit?" },
+      { move: "rule_change",   text: "Knowing-how vs knowing-that?" }
+    ],
+    pressure: "Is tasting a new fruit the same kind of knowing as ‘bat-feeling’? What’s similar or different?",
+    revisePrompt: "Want to refine your rule?"
+  }],
+  cave: [{
+    title: "Shadow Cave",
+    concept: "Appearance and Reality",
+    starter: "If shadows look like horses, are they horses?",
+    options: [
+      { move: "reason",        text: "No—appearance isn’t reality, because…" },
+      { move: "question",      text: "When can appearance be enough?" },
+      { move: "counterexample",text: "AR masks that track perfectly?" },
+      { move: "rule_change",   text: "Trust appearances unless… (exceptions)" },
+      { move: "analogy",       text: "It’s like a mirror / picture…" }
+    ],
+    pressure: "Name a time a picture or reflection fooled you. Does your rule handle that?",
+    revisePrompt: "Add an exception?"
+  }],
+  donkey: [{
+    title: "Toy Tracks",
+    concept: "Sharing the Tracks",
+    starter: "A cart is rolling toward many toys. A lever can divert it onto your own toy. Should you pull it?",
+    options: [
+      { move: "reason",        text: "Yes—fewer toys break, because…" },
+      { move: "reason",        text: "No—don’t break your own toy, because…" },
+      { move: "question",      text: "Whose toys? Are any already broken?" },
+      { move: "counterexample",text: "What if the other toys are already broken?" },
+      { move: "rule_change",   text: "Don’t break things unless… (state rule)" }
+    ],
+    pressure: "Does the same rule work if it’s someone else’s toy?",
+    revisePrompt: "Write your ‘toy rule’ in 7 words."
+  }]
+};

--- a/js/sceneInquiry.js
+++ b/js/sceneInquiry.js
@@ -1,0 +1,86 @@
+/* js/sceneInquiry.js — open micro-dialog on first entry to selected scenes */
+(function(){
+  var opened = {}; // sceneId -> true
+  var active = null; // { sceneId, stepIndex, spec }
+
+  function letterFromSceneSpec(sceneId, spec, lastAnswer){
+    return {
+      letter: spec.title || "Scene",
+      concept: spec.concept || sceneId,
+      description: "",
+      starter: spec.starter,
+      options: (Array.isArray(spec.options) && spec.options.length ? spec.options : (window.INQUIRY_MOVES||[]).map(function(m){return {move:m.id, text:m.label};})),
+      answer: lastAnswer || "",
+      // flag so letters.js logs ‘scene:<id>’
+      _fromSceneId: sceneId
+    };
+  }
+
+  function showPressure(spec){
+    var box = document.getElementById('dialogueBox');
+    if (!box) return;
+    var html = "";
+    if (spec.pressure) html += "<p><em>"+spec.pressure+"</em></p>";
+    if (spec.revisePrompt) html += "<p>"+spec.revisePrompt+"</p>";
+    html += '<p><button id="reviseBtn">Revise</button> <button id="continueBtn2">Continue</button></p>';
+    box.innerHTML = html;
+    box.style.display = 'block';
+    var revise = document.getElementById('reviseBtn');
+    var cont = document.getElementById('continueBtn2');
+    if (revise) revise.onclick = function(){
+      if (!active) {
+        box.style.display = 'none';
+        return;
+      }
+      // reopen the letter-like UI prefilled with last reason if available
+      var spec2 = active && active.spec ? active.spec : spec;
+      var ltr = letterFromSceneSpec(active.sceneId, spec2, active && active.lastReason);
+      if (window.showLetterInfo) showLetterInfo(ltr);
+      box.style.display = 'none';
+    };
+    if (cont) cont.onclick = function(){
+      box.style.display = 'none';
+    };
+  }
+
+  // public
+  window.maybeOpenSceneInquiry = function(sceneId){
+    if (!window.SCENE_DIALOGS || !SCENE_DIALOGS[sceneId]) return;
+    if (opened[sceneId]) return;
+    opened[sceneId] = true;
+    var spec = SCENE_DIALOGS[sceneId][0];
+    active = { sceneId: sceneId, stepIndex: 0, spec: spec, lastReason: '' };
+    // Use the letter overlay UI for the starter step
+    var ltr = letterFromSceneSpec(sceneId, spec, active.lastReason);
+    if (window.showLetterInfo) showLetterInfo(ltr);
+  };
+
+  // Chain the pressure/revise panel after the player saves a reason
+  var oldHook = window.onAfterInquirySave;
+  window.onAfterInquirySave = function(payload){
+    try {
+      if (active && payload && payload.letter && payload.letter._fromSceneId === active.sceneId) {
+        active.lastReason = payload.letter.answer || '';
+        showPressure(active.spec);
+      }
+    } finally {
+      if (typeof oldHook === 'function') oldHook(payload);
+    }
+  };
+
+  // Best-effort: if there is a known scene-change function, append our call
+  function attachAfter(fnName){
+    var fn = window[fnName];
+    if (typeof fn !== 'function') return false;
+    window[fnName] = function(sceneId){
+      var r = fn.apply(this, arguments);
+      try { window.maybeOpenSceneInquiry(sceneId); } catch(e){}
+      return r;
+    };
+    return true;
+  }
+  // Try a few likely names; the first that exists gets patched
+  if (!(attachAfter('goToScene') || attachAfter('changeScene') || attachAfter('setScene'))) {
+    // If none found, nothing breaks; you can manually call maybeOpenSceneInquiry(sceneId) where you set the scene.
+  }
+})();

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -597,6 +597,9 @@ function draw() {
   }
   if (sceneHistory[sceneHistory.length - 1] !== currentScene) {
     sceneHistory.push(currentScene);
+    if (typeof window.maybeOpenSceneInquiry === 'function') {
+      window.maybeOpenSceneInquiry(currentScene);
+    }
     if (currentScene === 'dogHouse') {
       dogHouseVisits++;
       dialoguesPlayed['dogHouseReturn'] = false;


### PR DESCRIPTION
## Summary
- load new micro-dialogue content for selected scenes and show it via the existing inquiry UI
- extend the letter save handler to log richer context, expose an after-save hook, and improve keyboard/ARIA support
- trigger the inquiry overlay after scene changes so scenes can launch their prompts once

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e595ccbd8c83229a3474d0b4600947