### PR TITLE
Add scene micro-dialogues and letter-specific move overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <!-- Inquiry moves + Reason trace -->
   <script src="js/moves.js"></script>
   <script src="js/trace.js"></script>
+  <script src="js/letterOverrides.js"></script>
   <script src="js/sceneDialogs.js"></script>
   <script src="js/sceneInquiry.js"></script>
   <script src="js/scenes.js"></script>

--- a/js/letterOverrides.js
+++ b/js/letterOverrides.js
@@ -1,0 +1,211 @@
+/* js/letterOverrides.js — fit-for-purpose options per letter. Safe: only merges if letter matches. */
+
+window.LETTER_OVERRIDES = {
+  A: { // Autonomy
+    starter: "Should parents ever decide for you?",
+    options: [
+      { move:"reason",        text:"Yes—safety comes first, because…" },
+      { move:"reason",        text:"No—choosing is how I learn, because…" },
+      { move:"question",      text:"What counts as a ‘big’ choice?" },
+      { move:"counterexample",text:"What if I want to do something risky?" },
+      { move:"rule_change",   text:"Adults guide; kids decide when ready." }
+    ],
+    pressure: "Does your rule change with age or situation?",
+    revisePrompt: "Add an age/safety clause?"
+  },
+
+  B: { // Believing & evidence
+    starter: "Is it okay to believe with no evidence?",
+    options: [
+      { move:"reason",        text:"Yes—for fun hopes, because…" },
+      { move:"reason",        text:"No—beliefs guide actions, because…" },
+      { move:"question",      text:"What *is* evidence here?" },
+      { move:"counterexample",text:"A trusted friend’s promise?" },
+      { move:"rule_change",   text:"Okay for hopes; not for actions." }
+    ],
+    pressure: "What if a belief could harm someone?",
+    revisePrompt: "Add a harm clause?"
+  },
+
+  D: { // Difference/criteria
+    starter: "What makes a dog different from a cat?",
+    options: [
+      { move:"reason",        text:"Body/biology differences matter, because…" },
+      { move:"analogy",       text:"Jobs/behaviors differ (herding vs climbing), because…" },
+      { move:"question",      text:"Which differences *really* matter?" },
+      { move:"counterexample",text:"A dog that climbs and purrs?" },
+      { move:"rule_change",   text:"Differences by kind, not looks alone." }
+    ],
+    pressure: "Are there mixed cases? How do we decide?",
+    revisePrompt: "Tweak your criteria?"
+  },
+
+  E: { // Ethics
+    starter: "What’s the right thing to do here?",
+    options: [
+      { move:"reason",        text:"Help whoever needs it most, because…" },
+      { move:"reason",        text:"Keep our promise, because…" },
+      { move:"question",      text:"What’s the goal and who’s affected?" },
+      { move:"counterexample",text:"Promise vs saving someone?" },
+      { move:"rule_change",   text:"Rule with an emergency exception." }
+    ],
+    pressure: "Does your rule ever allow unfairness?",
+    revisePrompt: "Add a fairness clause?"
+  },
+
+  I: { // Identity over time
+    starter: "What makes something the same over time?",
+    options: [
+      { move:"reason",        text:"Same story/history matters, because…" },
+      { move:"reason",        text:"Same pieces matter, because…" },
+      { move:"question",      text:"What if parts are replaced slowly?" },
+      { move:"counterexample",text:"A bike with every part replaced?" },
+      { move:"rule_change",   text:"Same if memory/projects continue." }
+    ],
+    pressure: "If we reassemble the old parts elsewhere, which is original?",
+    revisePrompt: "Choose story vs matter?"
+  },
+
+  J: { // Judging (fallibilism)
+    starter: "Are grown‑up judgments always right?",
+    options: [
+      { move:"reason",        text:"No—everyone can err, because…" },
+      { move:"reason",        text:"Often right—more experience, because…" },
+      { move:"question",      text:"What makes a judgment *good*?" },
+      { move:"counterexample",text:"A kid corrects an adult?" },
+      { move:"rule_change",   text:"Judge by reasons, not age." }
+    ],
+    pressure: "How should we handle disagreement kindly?",
+    revisePrompt: "Add a civility step?"
+  },
+
+  K: { // Knowledge sources
+    starter: "How do you gain knowledge?",
+    options: [
+      { move:"reason",        text:"By seeing/doing it, because…" },
+      { move:"reason",        text:"By learning from others, because…" },
+      { move:"question",      text:"When is testimony enough?" },
+      { move:"counterexample",text:"A rumor that seems true?" },
+      { move:"rule_change",   text:"Prefer seeing; accept testimony with checks." }
+    ],
+    pressure: "What if seeing misleads (optical illusion)?",
+    revisePrompt: "Add a cross‑check?"
+  },
+
+  L: { // Logic
+    starter: "When do you use logic?",
+    options: [
+      { move:"reason",        text:"When I test if reasons fit, because…" },
+      { move:"analogy",       text:"Like math steps—each must follow." },
+      { move:"question",      text:"What makes a reason *valid*?" },
+      { move:"counterexample",text:"A reason that sounds right but doesn’t follow?" },
+      { move:"rule_change",   text:"‘If… then…’ needs a true ‘if’." }
+    ],
+    pressure: "Can true reasons still lead to wrong conclusions?",
+    revisePrompt: "Clarify your ‘if’ condition?"
+  },
+
+  M: { // Minds
+    starter: "Do other animals think and feel like we do?",
+    options: [
+      { move:"reason",        text:"Yes—similar brains/behavior, because…" },
+      { move:"reason",        text:"Some do, some don’t, because…" },
+      { move:"question",      text:"What *counts* as feeling?" },
+      { move:"counterexample",text:"An octopus solving puzzles?" },
+      { move:"rule_change",   text:"Respect unless strong evidence otherwise." }
+    ],
+    pressure: "Does your rule protect less showy animals?",
+    revisePrompt: "Add a ‘quiet animals’ clause?"
+  },
+
+  P: { // Promises
+    starter: "Is it ever okay to break a promise?",
+    options: [
+      { move:"reason",        text:"Yes—when keeping it causes harm, because…" },
+      { move:"reason",        text:"No—promises build trust, because…" },
+      { move:"question",      text:"What counts as a good excuse?" },
+      { move:"counterexample",text:"A promise vs a real emergency?" },
+      { move:"rule_change",   text:"Keep promises except emergency cases." }
+    ],
+    pressure: "What about small harms vs big harms?",
+    revisePrompt: "Add a threshold?"
+  },
+
+  Q: { // Qualia
+    starter: "What is it like to taste a new fruit?",
+    options: [
+      { move:"reason",        text:"You only know by trying, because…" },
+      { move:"question",      text:"Can a description ever be enough?" },
+      { move:"counterexample",text:"A flavor you already know well?" },
+      { move:"analogy",       text:"Like riding a bike—you must try." },
+      { move:"rule_change",   text:"Try first when safe; read to prepare." }
+    ],
+    pressure: "When is ‘read first’ wiser than ‘try first’?",
+    revisePrompt: "Add a safety clause?"
+  },
+
+  R: { // Reality (tooth fairy / make-believe)
+    starter: "Do you think the tooth fairy is real?",
+    options: [
+      { move:"reason",        text:"It’s a story we tell, because…" },
+      { move:"reason",        text:"It could be real—I lack proof, because…" },
+      { move:"question",      text:"What makes something *real*?" },
+      { move:"counterexample",text:"Money appears—does that count as evidence?" },
+      { move:"rule_change",   text:"Believe stories for fun; check claims for action." }
+    ],
+    pressure: "What would change your mind either way?",
+    revisePrompt: "Add an evidence test?"
+  },
+
+  S: { // Stories & truth
+    starter: "Are stories true?",
+    options: [
+      { move:"reason",        text:"True about feelings and values, because…" },
+      { move:"reason",        text:"Not true about facts without checks, because…" },
+      { move:"question",      text:"What kind of truth do you mean?" },
+      { move:"counterexample",text:"A story that gets a science fact right?" },
+      { move:"rule_change",   text:"Stories suggest; tests confirm." }
+    ],
+    pressure: "If many stories agree, does that count as evidence?",
+    revisePrompt: "Clarify ‘truth about what’?"
+  },
+
+  T: { // Truth
+    starter: "Why does truth matter?",
+    options: [
+      { move:"reason",        text:"It helps us solve problems together, because…" },
+      { move:"reason",        text:"It keeps us safe (medicine, maps), because…" },
+      { move:"question",      text:"How do we check what’s true?" },
+      { move:"counterexample",text:"A comforting false belief?" },
+      { move:"rule_change",   text:"Care for feelings; act on truths." }
+    ],
+    pressure: "When is comfort worth it, if ever?",
+    revisePrompt: "Add a care clause?"
+  },
+
+  X: { // eXperience
+    starter: "What can experience teach that reading can’t?",
+    options: [
+      { move:"reason",        text:"Skills—riding, tasting, balancing—because…" },
+      { move:"question",      text:"Can reading sometimes be enough?" },
+      { move:"counterexample",text:"Tasting a hot pepper after reading about it?" },
+      { move:"analogy",       text:"Like swimming—you must get wet." },
+      { move:"rule_change",   text:"Try first when safe; read to prepare." }
+    ],
+    pressure: "Can ‘try first’ ever be unsafe?",
+    revisePrompt: "Add a safety check?"
+  },
+
+  Y: { // You (virtue reflection)
+    starter: "Name one strength and one thing to practice.",
+    options: [
+      { move:"reason",        text:"Strength: … because…" },
+      { move:"reason",        text:"Practice: … because…" },
+      { move:"question",      text:"What helps you practice?" },
+      { move:"counterexample",text:"A time it didn’t work—what blocked you?" },
+      { move:"rule_change",   text:"Set a small daily step." }
+    ],
+    pressure: "How will you know it’s working?",
+    revisePrompt: "Add a check‑in?"
+  }
+};

--- a/js/letters.js
+++ b/js/letters.js
@@ -368,6 +368,9 @@ function checkDuckLetterCollision(duck) {
 function showLetterInfo(letter) {
   var box = document.getElementById('letterInfoBox');
   if (!box) return;
+  if (window.LETTER_OVERRIDES && LETTER_OVERRIDES[letter.letter]) {
+    Object.assign(letter, LETTER_OVERRIDES[letter.letter]);
+  }
   var starter = letter.starter || letter.question || 'What do you think?';
   var opts = Array.isArray(letter.options) && letter.options.length ? letter.options : _defaultOptionsForLetter(letter);
   if (opts && opts.length) {
@@ -414,8 +417,8 @@ function showLetterInfo(letter) {
     saveBtn.onclick = function(){
       var reason = (input && input.value ? input.value : '').slice(0,120);
       letter.answer = reason; // keeps compatibility with Answers view
-      try {
-        if (typeof logReason === 'function') {
+      if (typeof logReason === 'function') {
+        try {
           logReason({
             sceneOrLetter: letter.letter,
             concept: letter.concept || letter.title || '',
@@ -424,14 +427,16 @@ function showLetterInfo(letter) {
             confidence: _getConfidence(),
             context: (letter._fromSceneId ? ('scene:'+letter._fromSceneId) : 'letter')
           });
-        }
-        if (typeof scoreMove === 'function') { scoreMove(_selectedMoveId); }
-        if (typeof renderBadges === 'function') { renderBadges(); }
-        // Optional callback so scenes can chain a pressure/revise step
-        if (typeof window.onAfterInquirySave === 'function') {
-          window.onAfterInquirySave({ letter, move: _selectedMoveId });
-        }
-      } catch(e){}
+        } catch(e){}
+      }
+      if (typeof scoreMove === 'function') { scoreMove(_selectedMoveId); }
+      if (typeof renderBadges === 'function') { renderBadges(); }
+      // Optional callback so scenes can chain a pressure/revise step
+      if (typeof window.onAfterInquirySave === 'function') {
+        try {
+          window.onAfterInquirySave({ letter: letter, move: _selectedMoveId });
+        } catch(e){}
+      }
       closeLetterInfo();
     };
   }

--- a/js/sceneDialogs.js
+++ b/js/sceneDialogs.js
@@ -1,8 +1,12 @@
-/* js/sceneDialogs.js — minimal micro-dialogue content for scenes */
-window.SCENE_DIALOGS = {
-  barnInside: [{
-    title: "Barn Bat",
-    concept: "Bat Feelings",
+/* js/sceneDialogs.js — scene micro-dialogues (starter → options → pressure → revise)
+   Notes:
+   - Keys should match your scene IDs. Unused keys are safe no-ops.
+   - Each scene opens once on first entry (handled by sceneInquiry.js).
+*/
+
+window.SCENE_DIALOGS = Object.assign(window.SCENE_DIALOGS || {}, {
+  // Classic philosophy of mind: Nagel
+  bat: [{
     starter: "If you knew every fact about bats, would you know bat-feeling?",
     options: [
       { move: "reason",        text: "Yes—facts are enough, because…" },
@@ -11,27 +15,27 @@ window.SCENE_DIALOGS = {
       { move: "counterexample",text: "What about tasting a new fruit?" },
       { move: "rule_change",   text: "Knowing-how vs knowing-that?" }
     ],
-    pressure: "Is tasting a new fruit the same kind of knowing as ‘bat-feeling’? What’s similar or different?",
+    pressure: "Is tasting a new fruit the same kind of knowing as ‘bat-feeling’? What's similar or different?",
     revisePrompt: "Want to refine your rule?"
   }],
+
+  // Classic epistemology/metaphysics: Plato
   cave: [{
-    title: "Shadow Cave",
-    concept: "Appearance and Reality",
     starter: "If shadows look like horses, are they horses?",
     options: [
       { move: "reason",        text: "No—appearance isn’t reality, because…" },
       { move: "question",      text: "When can appearance be enough?" },
       { move: "counterexample",text: "AR masks that track perfectly?" },
       { move: "rule_change",   text: "Trust appearances unless… (exceptions)" },
-      { move: "analogy",       text: "It’s like a mirror / picture…" }
+      { move: "analogy",       text: "It’s like a mirror/picture…" }
     ],
     pressure: "Name a time a picture or reflection fooled you. Does your rule handle that?",
     revisePrompt: "Add an exception?"
   }],
-  donkey: [{
-    title: "Toy Tracks",
-    concept: "Sharing the Tracks",
-    starter: "A cart is rolling toward many toys. A lever can divert it onto your own toy. Should you pull it?",
+
+  // Trolley-like toy rule
+  tracks: [{
+    starter: "A cart rolls toward many toys. A lever diverts it onto your own toy. Should you pull it?",
     options: [
       { move: "reason",        text: "Yes—fewer toys break, because…" },
       { move: "reason",        text: "No—don’t break your own toy, because…" },
@@ -41,5 +45,173 @@ window.SCENE_DIALOGS = {
     ],
     pressure: "Does the same rule work if it’s someone else’s toy?",
     revisePrompt: "Write your ‘toy rule’ in 7 words."
+  }],
+
+  // Identity/essence vs function
+  field: [{
+    starter: "If a robot looks, baas, and grazes like a sheep, is it a sheep?",
+    options: [
+      { move: "reason",        text: "Yes—same job/behaviors, because…" },
+      { move: "reason",        text: "No—being alive matters, because…" },
+      { move: "question",      text: "What makes something a ‘real’ sheep?" },
+      { move: "counterexample",text: "A toy sheep that can't grow wool?" },
+      { move: "rule_change",   text: "Call it a sheep if it can live and grow." }
+    ],
+    pressure: "Does your rule work for newborn lambs or sheared sheep?",
+    revisePrompt: "Tweak your ‘sheep rule’?"
+  }],
+
+  // Stereotypes/fairness; appearance vs evidence
+  dogHouse: [{
+    starter: "Should we judge Dog by looks or by evidence of behavior?",
+    options: [
+      { move: "reason",        text: "Evidence first—looks can mislead, because…" },
+      { move: "reason",        text: "Looks can matter for safety, because…" },
+      { move: "question",      text: "What counts as good evidence?" },
+      { move: "counterexample",text: "A calm dog that looks scary?" },
+      { move: "rule_change",   text: "Start with kindness; change with real facts." }
+    ],
+    pressure: "How much evidence is enough to change how we act?",
+    revisePrompt: "Add a safety clause?"
+  }],
+
+  // Sorites (heap)
+  picnic: [{
+    starter: "How many vegetables make a ‘heap’?",
+    options: [
+      { move: "reason",        text: "Set a number threshold, because…" },
+      { move: "question",      text: "Can a heap have fuzzy edges?" },
+      { move: "counterexample",text: "If we remove one carrot at a time… still a heap?" },
+      { move: "rule_change",   text: "Use a ‘close enough’ rule for vague words." },
+      { move: "analogy",       text: "Like ‘tall’ people—no sharp line." }
+    ],
+    pressure: "Your rule says a heap at N. What about N−1?",
+    revisePrompt: "Add a tolerance (‘about N’)?"
+  }],
+
+  // Animal minds/other minds
+  tunnel: [{
+    starter: "How can we tell if animals have feelings and thoughts?",
+    options: [
+      { move: "reason",        text: "Behavior shows it, because…" },
+      { move: "analogy",       text: "Their brains are like ours, so…" },
+      { move: "question",      text: "What would count as good evidence?" },
+      { move: "counterexample",text: "A robot says ‘I’m sad about the plant’?" },
+      { move: "rule_change",   text: "Treat beings with care unless strong evidence says not." }
+    ],
+    pressure: "Does your rule protect shy animals who don’t show feelings?",
+    revisePrompt: "Adjust for quiet behavior?"
+  }],
+
+  // Local right-action choice; care/deontology conflict
+  greenhouseInside: [{
+    starter: "What makes an action ‘the right thing’ here?",
+    options: [
+      { move: "reason",        text: "Do what helps plants thrive (care), because…" },
+      { move: "reason",        text: "Follow the rule we agreed on (duty), because…" },
+      { move: "question",      text: "What is the goal of this task?" },
+      { move: "counterexample",text: "What if breaking a small rule saves the seedlings?" },
+      { move: "rule_change",   text: "Rules with an emergency exception." }
+    ],
+    pressure: "Does your rule allow unfairness or harm by accident?",
+    revisePrompt: "Add a fairness/harm-prevention clause?"
+  }],
+
+  // Evidence/testimony hierarchy
+  radioRoom: [{
+    starter: "Two reports disagree—who should we trust?",
+    options: [
+      { move: "reason",        text: "The one with better track record, because…" },
+      { move: "question",      text: "Can we check ourselves (see or measure)?" },
+      { move: "counterexample",text: "A careful newbie vs a sloppy expert?" },
+      { move: "rule_change",   text: "Rank evidence: seeing > measuring > testimony." },
+      { move: "analogy",       text: "Like checking a recipe with a taste test." }
+    ],
+    pressure: "What if we can’t measure—how do we break the tie?",
+    revisePrompt: "Add a fallback (two independent sources)?"
+  }],
+
+  // Self & representation
+  mirror: [{
+    starter: "Is your mirror‑self really you?",
+    options: [
+      { move: "reason",        text: "No—it’s an image, because…" },
+      { move: "analogy",       text: "Like a photo/video call—not me, but about me." },
+      { move: "question",      text: "What makes ‘you’ you?" },
+      { move: "counterexample",text: "If the image moves *before* you do?" },
+      { move: "rule_change",   text: "Images stand for us but aren’t us." }
+    ],
+    pressure: "Does this rule work for avatars and recordings?",
+    revisePrompt: "Add a representation clause?"
+  }],
+
+  // Fiction & knowledge
+  studio: [{
+    starter: "Can we learn true things from made‑up stories?",
+    options: [
+      { move: "reason",        text: "Yes—about feelings/fairness, because…" },
+      { move: "reason",        text: "Not about facts (like how many carrots), because…" },
+      { move: "question",      text: "Which truths are we after?" },
+      { move: "counterexample",text: "A story that teaches a real science fact?" },
+      { move: "rule_change",   text: "Stories teach values; facts need checking." }
+    ],
+    pressure: "If many stories agree, does that count as evidence?",
+    revisePrompt: "Add ‘stories suggest, tests confirm’?"
+  }],
+
+  // Question quality (meta-epistemology)
+  bench: [{
+    starter: "What makes a *good* question?",
+    options: [
+      { move: "reason",        text: "It leads to more questions, because…" },
+      { move: "reason",        text: "It asks for reasons, not just answers, because…" },
+      { move: "question",      text: "How can we test if a question is good?" },
+      { move: "counterexample",text: "A tricky question that confuses everyone?" },
+      { move: "rule_change",   text: "Good = clear, invites reasons, worth debating." }
+    ],
+    pressure: "Can a yes/no question ever be good? When?",
+    revisePrompt: "Refine your test?"
+  }],
+
+  // Environmental value
+  pond: [{
+    starter: "Why protect nature here—what kind of value does it have?",
+    options: [
+      { move: "reason",        text: "Beauty matters even if no one sees it, because…" },
+      { move: "reason",        text: "It helps us live (air, water), because…" },
+      { move: "question",      text: "Do plants/animals have rights?" },
+      { move: "counterexample",text: "What if saving one harms many?" },
+      { move: "rule_change",   text: "Care for ecosystems unless strong reason not." }
+    ],
+    pressure: "Does your rule cover tiny creatures too?",
+    revisePrompt: "Add a small‑life clause?"
+  }],
+
+  // Counting truth
+  vegetables: [{
+    starter: "If we disagree about how many carrots there are, can we both be right?",
+    options: [
+      { move: "reason",        text: "No—counting settles it, because…" },
+      { move: "analogy",       text: "It’s not like favorite colors." },
+      { move: "question",      text: "Are we counting the same thing?" },
+      { move: "counterexample",text: "Carrot pieces vs whole carrots?" },
+      { move: "rule_change",   text: "Truth tracks the world, not wishes." }
+    ],
+    pressure: "What if the light is bad—do we pause and check?",
+    revisePrompt: "Add a ‘check when unsure’ step?"
+  }],
+
+  // Generalization & counterexample
+  vegetables2: [{
+    starter: "Are all carrots orange?",
+    options: [
+      { move: "reason",        text: "Yes—every carrot I’ve seen is, because…" },
+      { move: "counterexample",text: "Purple carrots exist!" },
+      { move: "question",      text: "What counts as a real counterexample?" },
+      { move: "rule_change",   text: "Change to: ‘Many carrots are orange.’" },
+      { move: "analogy",       text: "Like birds—most fly, but not all." }
+    ],
+    pressure: "Does one counterexample break a rule or just narrow it?",
+    revisePrompt: "Weaken the generalization?"
   }]
-};
+});

--- a/js/scenes.js
+++ b/js/scenes.js
@@ -132,6 +132,9 @@ function handleSceneClicks(mx, my) {
         if (typeof stopDialogue === 'function') stopDialogue();
         if (typeof hideLetterInfo === 'function') hideLetterInfo();
         currentScene = dest;
+        if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+          window.maybeOpenSceneInquiry(currentScene);
+        }
         if (typeof orderedScenes !== 'undefined') {
           const idx = orderedScenes.indexOf(dest);
           if (idx !== -1) sceneIndex = idx;
@@ -153,6 +156,9 @@ function handleSceneClicks(mx, my) {
       if (typeof stopDialogue === 'function') stopDialogue();
       if (typeof hideLetterInfo === 'function') hideLetterInfo();
       currentScene = 'dogHouse';
+      if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+        window.maybeOpenSceneInquiry(currentScene);
+      }
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('dogHouse');
       }
@@ -170,6 +176,9 @@ function handleSceneClicks(mx, my) {
       if (typeof stopDialogue === 'function') stopDialogue();
       if (typeof hideLetterInfo === 'function') hideLetterInfo();
       currentScene = 'field';
+      if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+        window.maybeOpenSceneInquiry(currentScene);
+      }
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('field');
       }
@@ -184,6 +193,9 @@ function handleSceneClicks(mx, my) {
       if (typeof stopDialogue === 'function') stopDialogue();
       if (typeof hideLetterInfo === 'function') hideLetterInfo();
       currentScene = 'swing';
+      if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+        window.maybeOpenSceneInquiry(currentScene);
+      }
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('swing');
       }
@@ -198,6 +210,9 @@ function handleSceneClicks(mx, my) {
       if (typeof stopDialogue === 'function') stopDialogue();
       if (typeof hideLetterInfo === 'function') hideLetterInfo();
       currentScene = 'flowers';
+      if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+        window.maybeOpenSceneInquiry(currentScene);
+      }
       if (typeof orderedScenes !== 'undefined') {
         sceneIndex = orderedScenes.indexOf('flowers');
       }
@@ -278,6 +293,9 @@ function handleSceneClicks(mx, my) {
         if (typeof stopDialogue === 'function') stopDialogue();
         if (typeof hideLetterInfo === 'function') hideLetterInfo();
         currentScene = area.name;
+        if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+          window.maybeOpenSceneInquiry(currentScene);
+        }
         if (area.name === 'loftEntrance') {
           sceneIndex = orderedScenes.indexOf('loftEntrance');
         } else {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -995,6 +995,9 @@ function mousePressed() {
         }
         if (typeof stopDialogue === 'function') stopDialogue();
         currentScene = 'donkey';
+        if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+          window.maybeOpenSceneInquiry(currentScene);
+        }
         sceneIndex = orderedScenes.indexOf('barn');
         return;
       }
@@ -1010,6 +1013,9 @@ function mousePressed() {
         }
         if (typeof stopDialogue === 'function') stopDialogue();
         currentScene = 'barnInside';
+        if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+          window.maybeOpenSceneInquiry(currentScene);
+        }
         sceneIndex = orderedScenes.indexOf('barnInside');
         return;
       }
@@ -1024,6 +1030,9 @@ function mousePressed() {
       if (typeof playSound === 'function') playSound('click');
       if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'barn';
+      if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+        window.maybeOpenSceneInquiry(currentScene);
+      }
       sceneIndex = orderedScenes.indexOf('barn');
       return;
     }
@@ -1041,6 +1050,9 @@ function mousePressed() {
       if (typeof playSound === 'function') playSound('click');
       if (typeof stopDialogue === 'function') stopDialogue();
       currentScene = 'farmMap';
+      if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+        window.maybeOpenSceneInquiry(currentScene);
+      }
       return;
     }
   }
@@ -1153,6 +1165,9 @@ function advanceScene() {
     if (typeof stopDialogue === 'function') stopDialogue();
     if (typeof hideLetterInfo === 'function') hideLetterInfo();
     currentScene = 'barn';
+    if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+      window.maybeOpenSceneInquiry(currentScene);
+    }
     sceneIndex = orderedScenes.indexOf('barn');
     continueBtn.style.display = 'none';
     return;
@@ -1162,6 +1177,9 @@ function advanceScene() {
     if (typeof stopDialogue === 'function') stopDialogue();
     if (typeof hideLetterInfo === 'function') hideLetterInfo();
     currentScene = 'barnInside';
+    if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+      window.maybeOpenSceneInquiry(currentScene);
+    }
     sceneIndex = orderedScenes.indexOf('barnInside');
     continueBtn.style.display = 'none';
     return;
@@ -1175,6 +1193,9 @@ function advanceScene() {
     if (typeof stopDialogue === 'function') stopDialogue();
     if (typeof hideLetterInfo === 'function') hideLetterInfo();
     currentScene = 'farmMap';
+    if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+      window.maybeOpenSceneInquiry(currentScene);
+    }
     sceneIndex = orderedScenes.indexOf('farmMap');
     continueBtn.style.display = 'none';
     return;
@@ -1188,6 +1209,9 @@ function advanceScene() {
   if (typeof stopDialogue === 'function') stopDialogue();
   if (typeof hideLetterInfo === 'function') hideLetterInfo();
   currentScene = orderedScenes[sceneIndex];
+  if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+    window.maybeOpenSceneInquiry(currentScene);
+  }
   // Hide the button immediately after switching scenes; it will be
   // displayed again when the next dialogue finishes.
   continueBtn.style.display = 'none';
@@ -1199,6 +1223,9 @@ function goBackScene() {
     if (typeof playSound === 'function') playSound('back');
     if (typeof stopDialogue === 'function') stopDialogue();
     currentScene = sceneHistory[sceneHistory.length - 1];
+    if (typeof window !== 'undefined' && typeof window.maybeOpenSceneInquiry === 'function') {
+      window.maybeOpenSceneInquiry(currentScene);
+    }
     const idx = orderedScenes.indexOf(currentScene);
     if (idx !== -1) sceneIndex = idx;
     continueBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- add per-scene Socratic micro-dialogue content and hook it into gameplay so each scene opens once with pressure-and-revise follow ups
- introduce letter-specific move overrides that tailor prompts, moves, and pressure questions while keeping existing inquiry UI accessible
- ensure scene transitions trigger the new inquiries and logging captures concept/context for exports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a3cb07fc8322a6fb81626e291507