### PR TITLE
Add start notification guiding players to click dialogue

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
   <div id="letterInfoBox" aria-live="polite"></div>
   <div id="dialogueBox" aria-live="polite"></div>
   <div id="adviceBox" aria-live="polite"></div>
+  <div id="notificationBox" aria-live="polite"></div>
   <div id="answersBox" aria-live="polite">
     <button id="closeAnswersBtn" aria-label="Close">X</button>
     <div id="answersContent"></div>

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -12,6 +12,7 @@ let mapUnlocked = false;
 let trayOnTable = 'trayB';
 let trayChoiceMade = false;
 let dialogueBox;
+let startNotificationShown = false;
 
 // Movement variables for the duck in pond2
 let duckTargetX = null;
@@ -533,6 +534,7 @@ function setup() {
   // backBtn.addEventListener('click', goBackScene);
   // backBtn.style.display = 'none';
   dialogueBox = document.getElementById('dialogueBox');
+  showStartNotification();
 }
 
 function draw() {
@@ -1108,6 +1110,20 @@ function showAdvice() {
   box.onclick = hide;
   setTimeout(hide, 6000);
   highlightMissingLetters(currentScene);
+}
+
+function showStartNotification() {
+  const box = document.getElementById('notificationBox');
+  if (!box || startNotificationShown) return;
+  startNotificationShown = true;
+  box.innerHTML = '<strong>Welcome!</strong><br>Click the dialogue box to keep the adventure going!';
+  box.style.display = 'block';
+  const hide = () => {
+    box.style.display = 'none';
+    box.removeEventListener('click', hide);
+  };
+  box.addEventListener('click', hide);
+  setTimeout(hide, 8000);
 }
 
 function showAnswers() {

--- a/style.css
+++ b/style.css
@@ -82,7 +82,9 @@ canvas {
 }
 
 /* Popup for letter information */
-#letterInfoBox {
+#letterInfoBox,
+#adviceBox,
+#notificationBox {
   position: absolute;
   top: 20px;
   left: 50%;
@@ -104,22 +106,12 @@ canvas {
   font-size: 22px;
 }
 
-#adviceBox {
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(255, 255, 255, 0.95);
-  padding: 15px 20px;
-  border: 4px solid #00b2ff;
-  border-radius: 10px;
-  font-size: 18px;
-  color: #222;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  max-width: 70%;
-  display: none;
-  z-index: 11;
-  text-align: center;
+#notificationBox {
+  cursor: pointer;
+}
+
+#notificationBox strong {
+  font-size: 22px;
 }
 
 #answersBox {
@@ -178,6 +170,7 @@ canvas {
   #dialogueBox,
   #letterInfoBox,
   #adviceBox,
+  #notificationBox,
   #answersBox {
     font-size: 16px;
     max-width: 90%;
@@ -189,7 +182,8 @@ canvas {
     font-size: 22px;
   }
   #letterInfoBox,
-  #adviceBox {
+  #adviceBox,
+  #notificationBox {
     font-size: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- add a notification banner at game start reminding players to click the dialogue box to advance
- style the banner consistently with existing UI boxes and ensure it auto-hides after a short delay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c87b3180832296ebd7f94f515798