### PR TITLE
Add default letter override stub

### DIFF
--- a/js/letterOverrides.js
+++ b/js/letterOverrides.js
@@ -1,0 +1,8 @@
+// Optional per-letter override definitions.
+// Customize letter prompts or metadata by assigning properties to specific letters.
+// Example:
+//   window.LETTER_OVERRIDES = {
+//     A: { starter: 'New starter question' }
+//   };
+// Keeping the object defined prevents 404 errors when the script is requested.
+window.LETTER_OVERRIDES = window.LETTER_OVERRIDES || {};


### PR DESCRIPTION
## Summary
- add the missing `js/letterOverrides.js` stub so the browser no longer requests a missing script
- document how to customize letter prompts through the override hook

## Testing
- npm run check-assets

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68ec1b0e524883229279f3d806a966bb)